### PR TITLE
Use Golang composition to extend helm/pkg/action in hypper/pkg/action

### DIFF
--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	helmAction "helm.sh/helm/v3/pkg/action"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -23,7 +24,11 @@ func main() {
 	logger := logcli.NewStandard()
 	log.Current = logger
 
-	actionConfig := new(action.Configuration)
+	helmActionConfig := new(helmAction.Configuration)
+	actionConfig := &action.Configuration{
+		Configuration: helmActionConfig,
+	}
+
 	cmd, err := newRootCmd(actionConfig, log.Current, os.Args[1:])
 	if settings.Debug {
 		logger.Level = log.DebugLevel
@@ -42,7 +47,7 @@ func main() {
 
 	cobra.OnInitialize(func() {
 		helmDriver := os.Getenv("HELM_DRIVER")
-		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, logger.Debugf); err != nil {
+		if err := actionConfig.Configuration.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, logger.Debugf); err != nil {
 			log.Fatal(err)
 		}
 		if helmDriver == "memory" {

--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/Masterminds/log-go"
 	logcli "github.com/Masterminds/log-go/impl/cli"
+	"github.com/rancher-sandbox/hypper/pkg/action"
 	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
-	helmAction "helm.sh/helm/v3/pkg/action"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/storage/driver"
@@ -23,7 +23,7 @@ func main() {
 	logger := logcli.NewStandard()
 	log.Current = logger
 
-	actionConfig := new(helmAction.Configuration)
+	actionConfig := new(action.Configuration)
 	cmd, err := newRootCmd(actionConfig, log.Current, os.Args[1:])
 	if settings.Debug {
 		logger.Level = log.DebugLevel
@@ -58,7 +58,7 @@ func main() {
 
 // This function loads releases into the memory storage if the
 // environment variable is properly set.
-func loadReleasesInMemory(actionConfig *helmAction.Configuration) {
+func loadReleasesInMemory(actionConfig *action.Configuration) {
 	filePaths := strings.Split(os.Getenv("HELM_MEMORY_DRIVER_DATA"), ":")
 	if len(filePaths) == 0 {
 		return

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -93,11 +93,14 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		return nil, "", err
 	}
 
-	actionConfig := &helmAction.Configuration{
+	helmActionConfig := helmAction.Configuration{
 		Releases:     store,
 		KubeClient:   &kubefake.PrintingKubeClient{Out: ioutil.Discard},
 		Capabilities: chartutil.DefaultCapabilities,
 		Log:          func(format string, v ...interface{}) {},
+	}
+	actionConfig := &action.Configuration{
+		Configuration: &helmActionConfig,
 	}
 
 	// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Masterminds/log-go"
 	"github.com/rancher-sandbox/hypper/internal/test"
+	helmAction "helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chartutil"
 	kubefake "helm.sh/helm/v3/pkg/kube/fake"
 	"helm.sh/helm/v3/pkg/release"
@@ -18,15 +19,15 @@ import (
 
 	logcli "github.com/Masterminds/log-go/impl/cli"
 	"github.com/mattn/go-shellwords"
+	"github.com/rancher-sandbox/hypper/pkg/action"
 	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/spf13/cobra"
-	helmAction "helm.sh/helm/v3/pkg/action"
 )
 
 func testTimestamper() time.Time { return time.Unix(242085845, 0).UTC() }
 
 func init() {
-	helmAction.Timestamper = testTimestamper
+	action.Timestamper = testTimestamper
 }
 
 func runTestCmd(t *testing.T, tests []cmdTestCase) {
@@ -160,7 +161,7 @@ func resetEnv() func() {
 func executeCommandStdinC(cmd string) (*cobra.Command, string, error) {
 
 	args, err := shellwords.Parse(cmd)
-	actionConfig := new(helmAction.Configuration)
+	actionConfig := new(action.Configuration)
 
 	if err != nil {
 		return nil, "", err

--- a/cmd/hypper/list.go
+++ b/cmd/hypper/list.go
@@ -25,8 +25,8 @@ import (
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
 
+	"github.com/rancher-sandbox/hypper/pkg/action"
 	"helm.sh/helm/v3/cmd/helm/require"
-	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
 

--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/Masterminds/log-go"
 	"github.com/fatih/color"
+	"github.com/rancher-sandbox/hypper/pkg/action"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	helmAction "helm.sh/helm/v3/pkg/action"
 )
 
 var globalUsage = `Usage: hypper command
@@ -16,7 +16,7 @@ var globalUsage = `Usage: hypper command
 A package manager built on Helm charts and Helm itself.
 `
 
-func newRootCmd(actionConfig *helmAction.Configuration, logger log.Logger, args []string) (*cobra.Command, error) {
+func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:          "hypper",
 		Short:        "A package manager built on Helm charts and Helm itself",

--- a/cmd/hypper/uninstall.go
+++ b/cmd/hypper/uninstall.go
@@ -4,16 +4,16 @@ import (
 	"time"
 
 	"github.com/Masterminds/log-go"
+	"github.com/rancher-sandbox/hypper/pkg/action"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/cmd/helm/require"
-	helmAction "helm.sh/helm/v3/pkg/action"
 )
 
 var uninstallDesc = `remove a helm deployment by wrapping helm calls`
 
-func newUninstallCmd(actionConfig *helmAction.Configuration, logger log.Logger) *cobra.Command {
-	client := helmAction.NewUninstall(actionConfig)
+func newUninstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra.Command {
+	client := action.NewUninstall(actionConfig)
 	cmd := &cobra.Command{
 		Use:   "uninstall [NAME]",
 		Short: "uninstall a deployment",

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -2,5 +2,9 @@
 
 The _pkg_ directory contains a set of directories that are Go packages. These
 packages are a Go library that other applications can import to make use of.
-The functionality in the hypper CLI that is not UI based is contained in these
+The functionality in the Hypper CLI that is not UI based is contained in these
 packages.
+
+For implementing these Hypper packages, we have chosen for now to extend by
+composition the ones provided by Helm, which allows us to keep the same
+structure meanwhile extending and providing _pkg_ for consumption.

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -1,0 +1,17 @@
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/time"
+)
+
+// Timestamper is a function capable of producing a timestamp.Timestamper.
+//
+// By default, this is a time.Time function from the Helm time package. This can
+// be overridden for testing though, so that timestamps are predictable.
+var Timestamper = time.Now
+
+// Configuration is a composite type of Helm's Configuration type
+type Configuration struct {
+	*action.Configuration
+}

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -1,0 +1,17 @@
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/action"
+)
+
+// List is a composite type of Helm's List type
+type List struct {
+	*action.List
+}
+
+// NewList constructs a new *List by embedding action.List
+func NewList(cfg *Configuration) *List {
+	return &List{
+		action.NewList(cfg.Configuration),
+	}
+}

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -1,0 +1,17 @@
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/action"
+)
+
+// Uninstall is a composite type of Helm's Uninstall type
+type Uninstall struct {
+	*action.Uninstall
+}
+
+// NewUninstall creates a new Uninstall by embedding action.Uninstall
+func NewUninstall(cfg *Configuration) *Uninstall {
+	return &Uninstall{
+		action.NewUninstall(cfg.Configuration),
+	}
+}


### PR DESCRIPTION
Provide a manageable API to __hypper/pkg/action__ by embedding __helm/pkg/action__ types inside of it. Use Golang composition and embedded fields for doing so.

This allows us to expand the action package slowly from Helm's, while presenting a Hypper API that can be consumed externally.

See commit comments for expanded explanations.

Upsides:
- The refactor allows us to keep the same structure as Helm (for easy upstreaming).
- Allows us to extend the code incrementally.
- Allows us to provide the __hypper/pkg/*__ for consumption.

Downsides:
- We need to disable checking for composites in `go vet`. Given that we don't compose any other types, and the types that we compose (__hypper/pkg/action__ and __hypper/pkg/*__ in the future) are under our control, I believe the trade-off really pays off.


Alternatives considered:
- Don't use composite types, and wrap Helm methods and functions instead: IMHO this becomes unreasonable, as changing functions keep pulling other functions to be changed. Plus, makes upstreaming more difficult. Still, it would provide a consumable API for __hypper/pkg/*__.
- Keep consuming __helm/pkg/*__ directly for now. Simplifies current development. but this will pull a lot of copy-pasted Helm code, and doesn't create a consumable API for _hypper/pkg*_. Feels more like working on a Helm fork, than on a separate program that calls Helm libraries.