### PR TITLE
Run golangci-lint on `make test`, add `make gen-test-golden`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           stable: '!contains(${{ matrix.go }}, "beta") && !contains(${{ matrix.go }}, "rc")'
       - name: Build Hypper
         run: make build
-      - name: Test Hypper
-        run: make test
+      - name: Unit test Hypper
+        run: make test-unit
       - name: Show Coverage of Hypper
         run: make coverage

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,13 @@ test-unit:
 	@echo "==> Running unit tests <=="
 	go test $(GOFLAGS) -run $(TESTS) $(PKG) $(TESTFLAGS)
 
+# Generate golden files used in unit tests
+.PHONY: gen-test-golden
+gen-test-golden:
+gen-test-golden: PKG = ./cmd/hypper ./pkg/action
+gen-test-golden: TESTFLAGS = -update
+gen-test-golden: test-unit
+
 .PHONY: test-style
 test-style:
 	@echo "==> Checking style <=="

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ install: build
 .PHONY: test
 test: lint build
 test: TESTFLAGS += -race -v
+test: test-style
 test: test-unit
 
 .PHONY: test-unit


### PR DESCRIPTION
- Run golangci-lint as part of `make test`. Just as Helm does, so we don't forget to run it when developing. 
  Adapt GH actions to not run golangci-lint twice.
- Add `make gen-test-golden` target, analogous to Helm's.
