### PR TITLE
Add status command

### DIFF
--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -31,6 +31,7 @@ func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []st
 		newInstallCmd(actionConfig, logger),
 		newUninstallCmd(actionConfig, logger),
 		newListCmd(actionConfig, logger),
+		newStatusCmd(actionConfig, logger),
 	)
 
 	flags.ParseErrorsWhitelist.UnknownFlags = true

--- a/cmd/hypper/status.go
+++ b/cmd/hypper/status.go
@@ -1,0 +1,178 @@
+/*
+Copyright The Helm Authors, SUSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/Masterminds/log-go"
+	logio "github.com/Masterminds/log-go/io"
+	"github.com/rancher-sandbox/hypper/pkg/action"
+	"github.com/spf13/cobra"
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/cli/output"
+	"helm.sh/helm/v3/pkg/release"
+	"io"
+	"strings"
+	"time"
+)
+
+// NOTE: Keep the list of statuses up-to-date with pkg/release/status.go.
+var statusHelp = `
+This command shows the status of a named release.
+The status consists of:
+- last deployment time
+- k8s namespace in which the release lives
+- state of the release (can be: unknown, deployed, uninstalled, superseded, failed, uninstalling, pending-install, pending-upgrade or pending-rollback)
+- revision of the release
+- description of the release (can be completion message or error message, need to enable --show-desc)
+- list of resources that this release consists of, sorted by kind
+- details on last test suite run, if applicable
+- additional notes provided by the chart
+`
+
+func newStatusCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command {
+	client := action.NewStatus(cfg)
+	var outfmt output.Format
+
+	cmd := &cobra.Command{
+		Use:   "status RELEASE_NAME",
+		Short: "display the status of the named release",
+		Long:  statusHelp,
+		Args:  require.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Get an io.Writer compliant logger instance at the info level.
+			wInfo := logio.NewWriter(logger, log.InfoLevel)
+
+			rel, err := client.Run(args[0])
+			if err != nil {
+				return err
+			}
+
+			// strip chart metadata from the output
+			rel.Chart = nil
+
+			return outfmt.Write(wInfo, &statusPrinter{rel, false, client.ShowDescription})
+		},
+	}
+
+	f := cmd.Flags()
+
+	bindOutputFlag(cmd, &outfmt)
+	f.IntVar(&client.Version, "revision", 0, "if set, display the status of the named release with revision")
+	f.BoolVar(&client.ShowDescription, "show-desc", false, "if set, display the description message of the named release")
+
+	return cmd
+}
+
+type statusPrinter struct {
+	release         *release.Release
+	debug           bool
+	showDescription bool
+}
+
+func (s statusPrinter) WriteJSON(out io.Writer) error {
+	return output.EncodeJSON(out, s.release)
+}
+
+func (s statusPrinter) WriteYAML(out io.Writer) error {
+	return output.EncodeYAML(out, s.release)
+}
+
+func (s statusPrinter) WriteTable(out io.Writer) error {
+	if s.release == nil {
+		return nil
+	}
+	fmt.Fprintf(out, "NAME: %s\n", s.release.Name)
+	if !s.release.Info.LastDeployed.IsZero() {
+		fmt.Fprintf(out, "LAST DEPLOYED: %s\n", s.release.Info.LastDeployed.Format(time.ANSIC))
+	}
+	fmt.Fprintf(out, "NAMESPACE: %s\n", s.release.Namespace)
+	fmt.Fprintf(out, "STATUS: %s\n", s.release.Info.Status.String())
+	fmt.Fprintf(out, "REVISION: %d\n", s.release.Version)
+	if s.showDescription {
+		fmt.Fprintf(out, "DESCRIPTION: %s\n", s.release.Info.Description)
+	}
+
+	executions := executionsByHookEvent(s.release)
+	if tests, ok := executions[release.HookTest]; !ok || len(tests) == 0 {
+		fmt.Fprintln(out, "TEST SUITE: None")
+	} else {
+		for _, h := range tests {
+			// Don't print anything if hook has not been initiated
+			if h.LastRun.StartedAt.IsZero() {
+				continue
+			}
+			fmt.Fprintf(out, "TEST SUITE:     %s\n%s\n%s\n%s\n",
+				h.Name,
+				fmt.Sprintf("Last Started:   %s", h.LastRun.StartedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Last Completed: %s", h.LastRun.CompletedAt.Format(time.ANSIC)),
+				fmt.Sprintf("Phase:          %s", h.LastRun.Phase),
+			)
+		}
+	}
+
+	if s.debug {
+		fmt.Fprintln(out, "USER-SUPPLIED VALUES:")
+		err := output.EncodeYAML(out, s.release.Config)
+		if err != nil {
+			return err
+		}
+		// Print an extra newline
+		fmt.Fprintln(out)
+
+		cfg, err := chartutil.CoalesceValues(s.release.Chart, s.release.Config)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(out, "COMPUTED VALUES:")
+		err = output.EncodeYAML(out, cfg.AsMap())
+		if err != nil {
+			return err
+		}
+		// Print an extra newline
+		fmt.Fprintln(out)
+	}
+
+	if strings.EqualFold(s.release.Info.Description, "Dry run complete") || s.debug {
+		fmt.Fprintln(out, "HOOKS:")
+		for _, h := range s.release.Hooks {
+			fmt.Fprintf(out, "---\n# Source: %s\n%s\n", h.Path, h.Manifest)
+		}
+		fmt.Fprintf(out, "MANIFEST:\n%s\n", s.release.Manifest)
+	}
+
+	if len(s.release.Info.Notes) > 0 {
+		fmt.Fprintf(out, "NOTES:\n%s\n", strings.TrimSpace(s.release.Info.Notes))
+	}
+	return nil
+}
+
+func executionsByHookEvent(rel *release.Release) map[release.HookEvent][]*release.Hook {
+	result := make(map[release.HookEvent][]*release.Hook)
+	for _, h := range rel.Hooks {
+		for _, e := range h.Events {
+			executions, ok := result[e]
+			if !ok {
+				executions = []*release.Hook{}
+			}
+			result[e] = append(executions, h)
+		}
+	}
+	return result
+}

--- a/cmd/hypper/status_test.go
+++ b/cmd/hypper/status_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	helmtime "helm.sh/helm/v3/pkg/time"
+)
+
+func TestStatusCmd(t *testing.T) {
+	releasesMockWithStatus := func(info *release.Info, hooks ...*release.Hook) []*release.Release {
+		info.LastDeployed = helmtime.Unix(1452902400, 0).UTC()
+		return []*release.Release{{
+			Name:      "flummoxed-chickadee",
+			Namespace: "default",
+			Info:      info,
+			Chart:     &chart.Chart{},
+			Hooks:     hooks,
+		}}
+	}
+
+	tests := []cmdTestCase{{
+		name:   "get status of a deployed release",
+		cmd:    "status flummoxed-chickadee",
+		golden: "output/status.txt",
+		rels: releasesMockWithStatus(&release.Info{
+			Status: release.StatusDeployed,
+		}),
+	}, {
+		name:   "get status of a deployed release with desc",
+		cmd:    "status --show-desc flummoxed-chickadee",
+		golden: "output/status-with-desc.txt",
+		rels: releasesMockWithStatus(&release.Info{
+			Status:      release.StatusDeployed,
+			Description: "Mock description",
+		}),
+	}, {
+		name:   "get status of a deployed release with notes",
+		cmd:    "status flummoxed-chickadee",
+		golden: "output/status-with-notes.txt",
+		rels: releasesMockWithStatus(&release.Info{
+			Status: release.StatusDeployed,
+			Notes:  "release notes",
+		}),
+	}, {
+		name:   "get status of a deployed release with notes in json",
+		cmd:    "status flummoxed-chickadee -o json",
+		golden: "output/status.json",
+		rels: releasesMockWithStatus(&release.Info{
+			Status: release.StatusDeployed,
+			Notes:  "release notes",
+		}),
+	}, {
+		name:   "get status of a deployed release with test suite",
+		cmd:    "status flummoxed-chickadee",
+		golden: "output/status-with-test-suite.txt",
+		rels: releasesMockWithStatus(
+			&release.Info{
+				Status: release.StatusDeployed,
+			},
+			&release.Hook{
+				Name:   "never-run-test",
+				Events: []release.HookEvent{release.HookTest},
+			},
+			&release.Hook{
+				Name:   "passing-test",
+				Events: []release.HookEvent{release.HookTest},
+				LastRun: release.HookExecution{
+					StartedAt:   mustParseTime("2006-01-02T15:04:05Z"),
+					CompletedAt: mustParseTime("2006-01-02T15:04:07Z"),
+					Phase:       release.HookPhaseSucceeded,
+				},
+			},
+			&release.Hook{
+				Name:   "failing-test",
+				Events: []release.HookEvent{release.HookTest},
+				LastRun: release.HookExecution{
+					StartedAt:   mustParseTime("2006-01-02T15:10:05Z"),
+					CompletedAt: mustParseTime("2006-01-02T15:10:07Z"),
+					Phase:       release.HookPhaseFailed,
+				},
+			},
+			&release.Hook{
+				Name:   "passing-pre-install",
+				Events: []release.HookEvent{release.HookPreInstall},
+				LastRun: release.HookExecution{
+					StartedAt:   mustParseTime("2006-01-02T15:00:05Z"),
+					CompletedAt: mustParseTime("2006-01-02T15:00:07Z"),
+					Phase:       release.HookPhaseSucceeded,
+				},
+			},
+		),
+	}}
+	runTestCmd(t, tests)
+}
+
+func mustParseTime(t string) helmtime.Time {
+	res, _ := helmtime.Parse(time.RFC3339, t)
+	return res
+}

--- a/cmd/hypper/testdata/output/status-with-desc.txt
+++ b/cmd/hypper/testdata/output/status-with-desc.txt
@@ -1,0 +1,7 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 00:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+DESCRIPTION: Mock description
+TEST SUITE: None

--- a/cmd/hypper/testdata/output/status-with-notes.txt
+++ b/cmd/hypper/testdata/output/status-with-notes.txt
@@ -1,0 +1,8 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 00:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE: None
+NOTES:
+release notes

--- a/cmd/hypper/testdata/output/status-with-test-suite.txt
+++ b/cmd/hypper/testdata/output/status-with-test-suite.txt
@@ -1,0 +1,13 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 00:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE:     passing-test
+Last Started:   Mon Jan  2 15:04:05 2006
+Last Completed: Mon Jan  2 15:04:07 2006
+Phase:          Succeeded
+TEST SUITE:     failing-test
+Last Started:   Mon Jan  2 15:10:05 2006
+Last Completed: Mon Jan  2 15:10:07 2006
+Phase:          Failed

--- a/cmd/hypper/testdata/output/status.json
+++ b/cmd/hypper/testdata/output/status.json
@@ -1,0 +1,1 @@
+{"name":"flummoxed-chickadee","info":{"first_deployed":"","last_deployed":"2016-01-16T00:00:00Z","deleted":"","status":"deployed","notes":"release notes"},"namespace":"default"}

--- a/cmd/hypper/testdata/output/status.txt
+++ b/cmd/hypper/testdata/output/status.txt
@@ -1,0 +1,6 @@
+NAME: flummoxed-chickadee
+LAST DEPLOYED: Sat Jan 16 00:00:00 2016
+NAMESPACE: default
+STATUS: deployed
+REVISION: 0
+TEST SUITE: None

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -1,0 +1,34 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/action"
+)
+
+// Status is the action for checking the deployment status of releases.
+//
+// It provides the implementation of 'helm status'.
+type Status struct {
+	*action.Status
+	cfg *Configuration
+}
+
+// NewStatus creates a new Status object with the given configuration.
+func NewStatus(cfg *Configuration) *Status {
+	return &Status{
+		action.NewStatus(cfg.Configuration),
+		cfg,
+	}
+}


### PR DESCRIPTION
Basically lifted from the helm status command with minor changes:
 - Uses log-go for output
 - Removes tests for auto completion as we dont have that yet

Fixes: #52 

Signed-off-by: Itxaka <igarcia@suse.com>