### PR TITLE
Add aliases and suggests to uninstall command

### DIFF
--- a/cmd/hypper/testdata/output/uninstall-no-args.txt
+++ b/cmd/hypper/testdata/output/uninstall-no-args.txt
@@ -4,6 +4,9 @@ Usage:  hypper uninstall [NAME] [flags]
 Usage:
   hypper uninstall [NAME] [flags]
 
+Aliases:
+  uninstall, del, delete, un
+
 Flags:
       --description string   add a custom description
       --dry-run              simulate a uninstall

--- a/cmd/hypper/uninstall.go
+++ b/cmd/hypper/uninstall.go
@@ -15,10 +15,12 @@ var uninstallDesc = `remove a helm deployment by wrapping helm calls`
 func newUninstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra.Command {
 	client := action.NewUninstall(actionConfig)
 	cmd := &cobra.Command{
-		Use:   "uninstall [NAME]",
-		Short: "uninstall a deployment",
-		Long:  uninstallDesc,
-		Args:  require.MinimumNArgs(1),
+		Use:        "uninstall [NAME]",
+		Short:      "uninstall a deployment",
+		Long:       uninstallDesc,
+		Aliases:    []string{"del", "delete", "un"},
+		SuggestFor: []string{"remove", "rm"},
+		Args:       require.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for i := 0; i < len(args); i++ {
 				logger.Info(eyecandy.ESPrintf(settings.NoEmojis, ":fire: uninstalling %s", args[i]))


### PR DESCRIPTION
This mimics Helm's UI by providing `hypper uninstall/delete/del/un` and
suggesting the `uninstall` command in case of asking for `remove/rm`.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>