### PR TITLE
copyright/license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,3 @@ jobs:
         run: make test-unit
       - name: Show Coverage of Hypper
         run: make coverage
-      - name: Check license
-        run: make license-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,5 @@ jobs:
         run: make test-unit
       - name: Show Coverage of Hypper
         run: make coverage
+      - name: Check license
+        run: make license-check

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,20 @@
+name: license-check
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+jobs:
+  license-check:
+    strategy:
+      matrix:
+        go-version: ["1.16.x"]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check license
+        run: make license-check

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -8,11 +8,7 @@ on:
   pull_request:
 jobs:
   license-check:
-    strategy:
-      matrix:
-        go-version: ["1.16.x"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ vet:
 fmt:
 	go fmt ./...
 
+.PHONY: license-check
+license-check:
+	@scripts/license_check.sh
+
 .PHONY: clean
 clean:
 	rm $(BINDIR)/$(BINNAME)

--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/list.go
+++ b/cmd/hypper/list.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/repo.go
+++ b/cmd/hypper/repo.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (

--- a/cmd/hypper/repo_add.go
+++ b/cmd/hypper/repo_add.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/repo_list.go
+++ b/cmd/hypper/repo_list.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors & SUSE.
+Copyright The Helm Authors & SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/repo_remove.go
+++ b/cmd/hypper/repo_remove.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/repo_remove_test.go
+++ b/cmd/hypper/repo_remove_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/repo_update.go
+++ b/cmd/hypper/repo_update.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/hypper/require/args.go
+++ b/cmd/hypper/require/args.go
@@ -1,3 +1,18 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package require
 
 import (

--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/root_test.go
+++ b/cmd/hypper/root_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/status.go
+++ b/cmd/hypper/status.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"strings"
+	"time"
+
 	"github.com/Masterminds/log-go"
 	logio "github.com/Masterminds/log-go/io"
 	"github.com/rancher-sandbox/hypper/pkg/action"
@@ -26,9 +30,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/release"
-	"io"
-	"strings"
-	"time"
 )
 
 // NOTE: Keep the list of statuses up-to-date with pkg/release/status.go.

--- a/cmd/hypper/uninstall.go
+++ b/cmd/hypper/uninstall.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/cmd/hypper/uninstall_test.go
+++ b/cmd/hypper/uninstall_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/internal/test/ensure/ensure.go
+++ b/internal/test/ensure/ensure.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors & SUSE.
+Copyright The Helm Authors & SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/pkg/action/status.go
+++ b/pkg/action/status.go
@@ -3,7 +3,9 @@ Copyright The Helm Authors.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package action
 
 import (

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/eyecandy/colors.go
+++ b/pkg/eyecandy/colors.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package eyecandy
 
 import (

--- a/pkg/eyecandy/emoji.go
+++ b/pkg/eyecandy/emoji.go
@@ -1,9 +1,25 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package eyecandy
 
 import (
 	"fmt"
-	"github.com/kyokomi/emoji/v2"
 	"regexp"
+
+	"github.com/kyokomi/emoji/v2"
 )
 
 func ESPrintf(emojisDisabled bool, format string, v ...interface{}) string {

--- a/pkg/eyecandy/emoji_test.go
+++ b/pkg/eyecandy/emoji_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright SUSE LLC.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package eyecandy
 
 import (

--- a/pkg/hypperpath/home.go
+++ b/pkg/hypperpath/home.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package helmpath calculates filesystem paths to Helm's configuration, cache and data.
 package hypperpath
 

--- a/pkg/hypperpath/home_unix_test.go
+++ b/pkg/hypperpath/home_unix_test.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !windows
 
 package hypperpath

--- a/pkg/hypperpath/home_windows_test.go
+++ b/pkg/hypperpath/home_windows_test.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build windows
 
 package hypperpath

--- a/pkg/hypperpath/lazypath.go
+++ b/pkg/hypperpath/lazypath.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package hypperpath
 
 import (

--- a/pkg/hypperpath/lazypath_darwin.go
+++ b/pkg/hypperpath/lazypath_darwin.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build darwin
 
 package hypperpath

--- a/pkg/hypperpath/lazypath_darwin_test.go
+++ b/pkg/hypperpath/lazypath_darwin_test.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build darwin
 
 package hypperpath

--- a/pkg/hypperpath/lazypath_unix.go
+++ b/pkg/hypperpath/lazypath_unix.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !windows,!darwin
 
 package hypperpath

--- a/pkg/hypperpath/lazypath_unix_test.go
+++ b/pkg/hypperpath/lazypath_unix_test.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build !windows,!darwin
 
 package hypperpath

--- a/pkg/hypperpath/lazypath_windows.go
+++ b/pkg/hypperpath/lazypath_windows.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build windows
 
 package hypperpath

--- a/pkg/hypperpath/lazypath_windows_test.go
+++ b/pkg/hypperpath/lazypath_windows_test.go
@@ -1,3 +1,16 @@
+// Copyright The Helm Authors, SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build windows
 
 package hypperpath

--- a/pkg/hypperpath/xdg/xdg.go
+++ b/pkg/hypperpath/xdg/xdg.go
@@ -1,3 +1,18 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // Package xdg holds constants pertaining to XDG Base Directory Specification.
 //
 // The XDG Base Directory Specification https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

--- a/pkg/repo/chartrepo.go
+++ b/pkg/repo/chartrepo.go
@@ -1,3 +1,19 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package repo
 
 import (

--- a/pkg/repo/index.go
+++ b/pkg/repo/index.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors & SUSE.
+Copyright The Helm Authors & SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/repo/repo_test.go
+++ b/pkg/repo/repo_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors, SUSE
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/scripts/license_check.sh
+++ b/scripts/license_check.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+FILES=$(find . -type f -name "*.go"|grep -v 'third_party'|grep -v 'testdata')
+FAIL=0
+
+for file in  $FILES; do
+    error=""
+    if [ $(grep -i 'copyright' ${file}|wc -l) -eq 0 ]; then
+        error="        - does not contain a copyright keyword"
+        ((FAIL=FAIL+1))
+    fi
+    if [ $(grep -i 'copyright' ${file}|grep SUSE|grep -v LLC| wc -l) -gt 0 ]; then
+        error="${error}
+        - contains keyword SUSE, but is missing LLC"
+        ((FAIL=FAIL+1))
+    fi
+
+    if [ $(grep -i 'apache' ${file}| wc -l) -eq 0 ]; then
+        error="${error}
+        - has no reference to the apache license"
+        ((FAIL=FAIL+1))
+    else
+        if [ $(grep 'Licensed under the Apache License, Version 2.0 (the "License");' ${file}| wc -l) -eq 0 ]; then
+            error="${error}
+            - is missing the complete the reference to the apache license"
+            ((FAIL=FAIL+1))
+        fi
+        if [ $(grep 'http://www.apache.org/licenses/LICENSE-2.0' ${file}| wc -l) -eq 0 ]; then
+            error="${error}
+            - is missing the link to the apache license"
+            ((FAIL=FAIL+1))
+        fi
+    fi
+    if [ -n "${error}" ]; then
+    echo "${file}:
+${error}
+"
+    fi
+done
+
+if [ $FAIL -gt 0 ]; then
+    echo "+------------------------------------------------------------------+"
+    echo "| Missing or inclomplete copyright/license headers! Please fix it! |"
+    echo "+------------------------------------------------------------------+"
+    echo " "
+    echo " Counted ${FAIL} violations."
+    echo " "
+    exit 1
+fi
+echo "+-----------------------------------------------+"
+echo "| License & copyright headers seem to be valid. |"
+echo "+-----------------------------------------------+"
+exit 0


### PR DESCRIPTION
This is a rudimentary checker for `make` or ci that checks if go files start with the `package` keyword, if it warns about (probable) missing license/copyright headers.

- Adds `make license-check` target

Closes #8 