### PR TITLE
Add missing flag to Install

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -70,7 +70,10 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 			return nil
 		},
 	}
-	addInstallFlags(cmd, cmd.Flags(), client, valueOpts)
+	f := cmd.Flags()
+	addInstallFlags(cmd, f, client, valueOpts)
+	addValueOptionsFlags(f, valueOpts)
+	addChartPathOptionsFlags(f, &client.ChartPathOptions)
 	bindOutputFlag(cmd, &outfmt)
 	return cmd
 }


### PR DESCRIPTION
When mimicking the addInstallFlags from Install we
missed the values flags and the chartoptions flags

Fixes: #68 

Signed-off-by: Itxaka <igarcia@suse.com>