### PR TITLE
Add missing action/upgrade.go license

### DIFF
--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -1,3 +1,18 @@
+/*
+Copyright The Helm Authors, SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package action
 
 import (


### PR DESCRIPTION
license checker was failing due merging 2 prs at the same
time, one that dixed all license headers and the other
that introduced this file, so the license checker was
green until now :D

Signed-off-by: Itxaka <igarcia@suse.com>