### PR TITLE
Fix namespace set on upgrade command

### DIFF
--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -43,7 +43,7 @@ import (
 func testTimestamper() time.Time { return time.Unix(242085845, 0).UTC() }
 
 func init() {
-	action.Timestamper = testTimestamper
+	helmAction.Timestamper = testTimestamper
 }
 
 func runTestCmd(t *testing.T, tests []cmdTestCase) {

--- a/cmd/hypper/testdata/output/upgrade-with-install-release-name.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-install-release-name.txt
@@ -1,0 +1,8 @@
+Release "jojo" does not exist. Installing it now. 🧰 
+Installing chart "jojo" in namespace "default"…
+NAME: jojo
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None

--- a/cmd/hypper/testdata/output/upgrade-with-release-name.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-release-name.txt
@@ -1,0 +1,7 @@
+Release "jojo" has been upgraded 🥳 
+NAME: jojo
+LAST DEPLOYED: Fri Sep  2 22:04:05 1977
+NAMESPACE: default
+STATUS: deployed
+REVISION: 3
+TEST SUITE: None

--- a/cmd/hypper/upgrade_test.go
+++ b/cmd/hypper/upgrade_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"github.com/rancher-sandbox/hypper/internal/test/ensure"
-	"helm.sh/helm/v3/pkg/action"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,17 +30,6 @@ import (
 	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/release"
 )
-
-// FIXME(itxaka): As far as I can see this is done in here so we can  fake the timestamp in the
-// results so they match the golden files
-// We already have this on hypper.go file and I would expect this to be automatically done as we load that file
-// in the case of helm it works exactly like that, their upgrade_test.go does not set the action.Timestamper, its
-// done on the helm_test.go file
-// I have no idea why, but if I dont change the Timestamper then it doesnt match the golden files because it
-// uses the default Time.Now() timestamper...
-func init() {
-	action.Timestamper = testTimestamper
-}
 
 func TestUpgradeCmd(t *testing.T) {
 	tmpChart := ensure.TempDir(t)

--- a/cmd/hypper/upgrade_test.go
+++ b/cmd/hypper/upgrade_test.go
@@ -138,6 +138,17 @@ func TestUpgradeCmd(t *testing.T) {
 			rels:   []*release.Release{relMock("funny-bunny", 1, ch)},
 		},
 		{
+			name:   "install a release with 'upgrade --install ' and release-name",
+			cmd:    fmt.Sprintf("upgrade -i --release-name jojo '%s'", chartPath),
+			golden: "output/upgrade-with-install-release-name.txt",
+		},
+		{
+			name:   "upgrade a release with --release-name",
+			cmd:    fmt.Sprintf("upgrade --release-name jojo '%s'", chartPath),
+			golden: "output/upgrade-with-release-name.txt",
+			rels:   []*release.Release{relMock("jojo", 2, ch)},
+		},
+		{
 			name:   "upgrade a release with wait",
 			cmd:    fmt.Sprintf("upgrade --wait '%s'", chartPath),
 			golden: "output/upgrade-with-wait.txt",

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -17,16 +17,14 @@ limitations under the License.
 package action
 
 import (
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
-	"strings"
 )
 
 // Upgrade is a composite type of Helm's Upgrade type
 type Upgrade struct {
 	*action.Upgrade
-	cfg         *Configuration
+	Config      *Configuration
 	ReleaseName string
 }
 
@@ -34,19 +32,13 @@ type Upgrade struct {
 func NewUpgrade(cfg *Configuration) *Upgrade {
 	return &Upgrade{
 		Upgrade: action.NewUpgrade(cfg.Configuration),
-		cfg:     cfg,
+		Config:  cfg,
 	}
 }
 
 // Name returns the name that should be used.
-func (i *Upgrade) Name(chart *chart.Chart, args []string) (string, error) {
+func (i *Upgrade) Name(chart *chart.Chart) (string, error) {
 	// args here will only be: [CHART]
-	// cobra flags have been already stripped
-
-	if len(args) > 2 {
-		return args[0], errors.Errorf("expected at most two arguments, unexpected arguments: %v", strings.Join(args[2:], ", "))
-	}
-
 	if chart.Metadata.Annotations != nil {
 		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/release-name"]; ok {
 			return val, nil
@@ -58,4 +50,20 @@ func (i *Upgrade) Name(chart *chart.Chart, args []string) (string, error) {
 
 	// If we dont have our annotations then return the base name
 	return chart.Metadata.Name, nil
+}
+
+// SetNamespace sets the Namespace that should be used in action.Upgrade
+//
+// This will read the chart annotations. If no annotations, it leave the existing ns in the action.
+func (i *Upgrade) SetNamespace(chart *chart.Chart, defaultns string) {
+	i.Namespace = defaultns
+	if chart.Metadata.Annotations != nil {
+		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/namespace"]; ok {
+			i.Namespace = val
+		} else {
+			if val, ok := chart.Metadata.Annotations["catalog.cattle.io/namespace"]; ok {
+				i.Namespace = val
+			}
+		}
+	}
 }

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright The Helm Authors, SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import "github.com/stretchr/testify/assert"
+import "testing"
+
+func upgradeAction(t *testing.T) *Upgrade {
+	config := actionConfigFixture(t)
+	upgrAction := NewUpgrade(config)
+
+	return upgrAction
+}
+
+func TestUpgradeSetNamespace(t *testing.T) {
+	is := assert.New(t)
+
+	// chart without annotations
+	upgrAction := upgradeAction(t)
+	chart := buildChart()
+	upgrAction.SetNamespace(chart, "defaultns")
+	is.Equal("defaultns", upgrAction.Namespace)
+
+	// hypper annotations have priority over fallback annotations
+	upgrAction = upgradeAction(t)
+	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
+	upgrAction.SetNamespace(chart, "defaultns")
+	is.Equal("hypper", upgrAction.Namespace)
+
+	// fallback annotations have priority over default ns
+	upgrAction = upgradeAction(t)
+	chart = buildChart(withFallbackAnnotations())
+	upgrAction.SetNamespace(chart, "defaultns")
+	is.Equal("fleet-system", upgrAction.Namespace)
+}
+
+func TestUpgradeName(t *testing.T) {
+	is := assert.New(t)
+
+	// hypper annotations have priority over fallback annotations
+	upgrAction := upgradeAction(t)
+	chart := buildChart(withHypperAnnotations(), withFallbackAnnotations())
+	name, err := upgrAction.Name(chart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	is.Equal("my-hypper-name", name)
+
+	// fallback annotations
+	upgrAction = upgradeAction(t)
+	chart = buildChart(withFallbackAnnotations())
+	name, err = upgrAction.Name(chart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	is.Equal("fleet", name)
+
+	// no annotations should default to the chart name
+	upgrAction = upgradeAction(t)
+	chart = buildChart()
+	name, err = upgrAction.Name(chart)
+	if err != nil {
+		t.Fatal(err)
+	}
+	is.Equal("hello", name)
+}


### PR DESCRIPTION
Namespace was not being set via annotations properly
for the upgrade command nor the install command called
from the upgrade

Fixes: #73 

Signed-off-by: Itxaka <igarcia@suse.com>