### PR TITLE
Fix the disconnect between namespaces on install

### DIFF
--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	cobra.OnInitialize(func() {
-		helmDriver := os.Getenv("HELM_DRIVER")
+		helmDriver := settings.HelmDriver
 		if err := actionConfig.Init(settings.RESTClientGetter(), settings.Namespace(), helmDriver, logger.Debugf); err != nil {
 			log.Fatal(err)
 		}
@@ -127,5 +127,5 @@ func loadReleasesInMemory(actionConfig *action.Configuration) {
 // Storage Driver to search for it. With this below we re-Init the configuration and hance the Storage Driver to
 // have the namespace correctly set in sync with the Release
 func ReinitConfigForNamespace(cfg *action.Configuration, namespace string, logger log.Logger) {
-	_ = cfg.Init(settings.RESTClientGetter(), namespace, os.Getenv("HELM_DRIVER"), logger.Debugf)
+	_ = cfg.Init(settings.RESTClientGetter(), namespace, settings.HelmDriver, logger.Debugf)
 }

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -17,7 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"github.com/Masterminds/log-go"
+	logio "github.com/Masterminds/log-go/io"
 	"github.com/pkg/errors"
+	"github.com/rancher-sandbox/hypper/pkg/action"
+	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"helm.sh/helm/v3/cmd/helm/require"
@@ -28,11 +32,6 @@ import (
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/release"
-
-	"github.com/Masterminds/log-go"
-	logio "github.com/Masterminds/log-go/io"
-	"github.com/rancher-sandbox/hypper/pkg/action"
-	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 )
 
 const installDesc = `
@@ -119,6 +118,9 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	} else {
 		client.SetNamespace(chartRequested, settings.Namespace())
 	}
+
+	// Reinit the config so we set the proper namespace of the Storage Driver
+	ReinitConfigForNamespace(client.Config, client.Namespace, logger)
 
 	client.Config.SetNamespace(client.Namespace)
 

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -75,6 +75,7 @@ type EnvSettings struct {
 	NoColors          bool
 	NoEmojis          bool
 	NamespaceFromFlag bool
+	HelmDriver        string
 }
 
 // New is a constructor of EnvSettings
@@ -95,6 +96,7 @@ func New() *EnvSettings {
 		RegistryConfig:   envOr("HYPPER_REGISTRY_CONFIG", hypperpath.ConfigPath("registry.json")),
 		RepositoryConfig: envOr("HYPPER_REPOSITORY_CONFIG", hypperpath.ConfigPath("repositories.yaml")),
 		RepositoryCache:  envOr("HYPPER_REPOSITORY_CACHE", hypperpath.CachePath("repository")),
+		HelmDriver:       os.Getenv("HELM_DRIVER"),
 
 		Verbose:  false,
 		NoColors: false,


### PR DESCRIPTION
This re-Inits the config so we can set the Storage Driver
namespace to what is obtained from the chart.

This is because on helm you can only set the namespace via
the --namespace flag which gets into the envsettings.namespace
and the helm.go loads that var into the Configuration object
during cobra.OnInitialize.

To maintain compatibility we do the same but then during
the command execution we read the chart annotations and
change the release namespace on the fly.
This is ok for the namespace install but the Storage Driver,
which is already loaded, has a different namespace
(usually default) and the Release gets stored in the wrong
namespace (stored *for* helm, for k8s is installed properly)
This results into a disconnection between where the release
is installed and where hypper/helm looks in the Storage Driver
to search for it.

With this below we re-Init the configuration and hance the
Storage Driver to have the namespace correctly set in sync
with the Release

Maybe fixes: #75 ???

Signed-off-by: Itxaka <igarcia@suse.com>