### PR TITLE
feat: Add `hypper shared-dep list` command

### DIFF
--- a/cmd/hypper/dependency_shared.go
+++ b/cmd/hypper/dependency_shared.go
@@ -1,0 +1,119 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"helm.sh/helm/v3/cmd/helm/require"
+	"helm.sh/helm/v3/pkg/action"
+)
+
+const dependencyDesc = `
+Manage the dependencies of a chart.
+
+Helm charts store their dependencies in 'charts/'. For chart developers, it is
+often easier to manage dependencies in 'Chart.yaml' which declares all
+dependencies.
+
+The dependency commands operate on that file, making it easy to synchronize
+between the desired dependencies and the actual dependencies stored in the
+'charts/' directory.
+
+For example, this Chart.yaml declares two dependencies:
+
+    # Chart.yaml
+    dependencies:
+    - name: nginx
+      version: "1.2.3"
+      repository: "https://example.com/charts"
+    - name: memcached
+      version: "3.2.1"
+      repository: "https://another.example.com/charts"
+
+
+The 'name' should be the name of a chart, where that name must match the name
+in that chart's 'Chart.yaml' file.
+
+The 'version' field should contain a semantic version or version range.
+
+The 'repository' URL should point to a Chart Repository. Helm expects that by
+appending '/index.yaml' to the URL, it should be able to retrieve the chart
+repository's index. Note: 'repository' can be an alias. The alias must start
+with 'alias:' or '@'.
+
+Starting from 2.2.0, repository can be defined as the path to the directory of
+the dependency charts stored locally. The path should start with a prefix of
+"file://". For example,
+
+    # Chart.yaml
+    dependencies:
+    - name: nginx
+      version: "1.2.3"
+      repository: "file://../dependency_chart/nginx"
+
+If the dependency chart is retrieved locally, it is not required to have the
+repository added to helm by "helm add repo". Version matching is also supported
+for this case.
+`
+
+const dependencyListDesc = `
+List all of the dependencies declared in a chart.
+
+This can take chart archives and chart directories as input. It will not alter
+the contents of a chart.
+
+This will produce an error if the chart cannot be loaded.
+`
+
+func newDependencyCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "dependency update|build|list",
+		Aliases: []string{"dep", "dependencies"},
+		Short:   "manage a chart's dependencies",
+		Long:    dependencyDesc,
+		Args:    require.NoArgs,
+	}
+
+	cmd.AddCommand(newDependencyListCmd(out))
+	cmd.AddCommand(newDependencyUpdateCmd(cfg, out))
+	cmd.AddCommand(newDependencyBuildCmd(cfg, out))
+
+	return cmd
+}
+
+func newDependencyListCmd(out io.Writer) *cobra.Command {
+	client := action.NewDependency()
+
+	cmd := &cobra.Command{
+		Use:     "list CHART",
+		Aliases: []string{"ls"},
+		Short:   "list the dependencies for the given chart",
+		Long:    dependencyListDesc,
+		Args:    require.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			chartpath := "."
+			if len(args) > 0 {
+				chartpath = filepath.Clean(args[0])
+			}
+			return client.List(chartpath, out)
+		},
+	}
+	return cmd
+}

--- a/cmd/hypper/dependency_shared_test.go
+++ b/cmd/hypper/dependency_shared_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Helm Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestDependencyListCmd(t *testing.T) {
+	noSuchChart := cmdTestCase{
+		name:      "No such chart",
+		cmd:       "dependency list /no/such/chart",
+		golden:    "output/dependency-list-no-chart-linux.txt",
+		wantError: true,
+	}
+
+	noDependencies := cmdTestCase{
+		name:   "No dependencies",
+		cmd:    "dependency list testdata/testcharts/alpine",
+		golden: "output/dependency-list-no-requirements-linux.txt",
+	}
+
+	if runtime.GOOS == "windows" {
+		noSuchChart.golden = "output/dependency-list-no-chart-windows.txt"
+		noDependencies.golden = "output/dependency-list-no-requirements-windows.txt"
+	}
+
+	tests := []cmdTestCase{noSuchChart,
+		noDependencies, {
+			name:   "Dependencies in chart dir",
+			cmd:    "dependency list testdata/testcharts/reqtest",
+			golden: "output/dependency-list.txt",
+		}, {
+			name:   "Dependencies in chart archive",
+			cmd:    "dependency list testdata/testcharts/reqtest-0.1.0.tgz",
+			golden: "output/dependency-list-archive.txt",
+		}}
+	runTestCmd(t, tests)
+}
+
+func TestDependencyFileCompletion(t *testing.T) {
+	checkFileCompletion(t, "dependency", false)
+}

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -123,6 +123,7 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	buf := new(bytes.Buffer)
 	logger := logcli.NewStandard()
 	logger.InfoOut = buf
+	logger.WarnOut = buf
 	logger.ErrorOut = buf
 	log.Current = logger
 

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -180,11 +180,11 @@ func resetEnv() func() {
 func executeCommandStdinC(cmd string) (*cobra.Command, string, error) {
 
 	args, err := shellwords.Parse(cmd)
-	actionConfig := new(action.Configuration)
-
 	if err != nil {
 		return nil, "", err
 	}
+
+	actionConfig := new(action.Configuration)
 
 	// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
 	buf := new(bytes.Buffer)

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -162,7 +162,6 @@ type cmdTestCase struct {
 	rels []*release.Release
 	// Number of repeats (in case a feature was previously flaky and the test checks
 	// it's now stably producing identical results). 0 means test is run exactly once.
-	// TODO(itxaka): Disabled for now, we are not using it but we may want to keep it 1:1 with helm?
 	repeat int
 }
 

--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -50,6 +50,7 @@ func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []st
 		newStatusCmd(actionConfig, logger),
 		newRepoCmd(logger),
 		newUpgradeCmd(actionConfig, logger),
+		newSharedDependencyCmd(actionConfig, logger),
 	)
 
 	flags.ParseErrorsWhitelist.UnknownFlags = true

--- a/cmd/hypper/testdata/output/shared-deps-list-deps.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-deps.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	not-installed
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-found.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-found.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	deployed     
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	not-installed
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/cmd/hypper/testdata/output/shared-deps-list-installed.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	deployed     
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/cmd/hypper/testdata/output/shared-deps-list-no-chart-linux.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-chart-linux.txt
@@ -1,0 +1,1 @@
+Error: stat /no/such/chart: no such file or directory

--- a/cmd/hypper/testdata/output/shared-deps-list-no-chart-windows.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-chart-windows.txt
@@ -1,0 +1,1 @@
+Error: CreateFile \no\such\chart: The system cannot find the path specified.

--- a/cmd/hypper/testdata/output/shared-deps-list-no-shared-deps-linux.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-shared-deps-linux.txt
@@ -1,0 +1,1 @@
+WARNING: No shared dependencies in testdata/testcharts/vanilla-helm

--- a/cmd/hypper/testdata/output/shared-deps-list-no-shared-deps-windows.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-shared-deps-windows.txt
@@ -1,0 +1,1 @@
+WARNING: No shared dependencies in testdata\testcharts\vanilla-helm

--- a/cmd/hypper/testdata/output/shared-deps-list-not-installed.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-not-installed.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	not-installed
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/cmd/hypper/testdata/testcharts/hypper-annot/Chart.yaml
+++ b/cmd/hypper/testdata/testcharts/hypper-annot/Chart.yaml
@@ -10,3 +10,10 @@ annotations:
   hypper.cattle.io/release-name: my-hypper-name
   catalog.cattle.io/namespace: fleet-system
   catalog.cattle.io/release-name: fleet
+  hypper.cattle.io/shared-dependencies: |
+    - name: prometheus
+      version: "13.3.1"
+      repository: "https://example.com/charts"
+    - name: postgresql
+      version: "10.3.11"
+      repository: "https://another.example.com/charts"

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -44,7 +44,7 @@ func (c *Configuration) SetNamespace(namespace string) {
 		i.Namespace = namespace
 		c.KubeClient = i
 
-		// When actionConfig.Init is called it setup up the driver with a
+		// When actionConfig.Init is called it sets up the driver with a
 		// namespace. We need to change the namespace for the driver because
 		// we know a new location. Here we detect what driver is already in
 		// use and recreate it with the new namespace.
@@ -87,6 +87,19 @@ func (c *Configuration) SetNamespace(namespace string) {
 			}
 			c.Releases = storage.Init(d)
 		}
+	// tester Client:
+	default:
+		var d *driver.Memory
+		if c.Releases != nil {
+			if mem, ok := c.Releases.Driver.(*driver.Memory); ok {
+				d = mem
+			}
+		}
+		if d == nil {
+			d = driver.NewMemory()
+		}
+		d.SetNamespace(namespace)
+		c.Releases = storage.Init(d)
 	}
 
 }

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -89,20 +89,20 @@ func buildChart(opts ...chartOption) *chart.Chart {
 
 func withHypperAnnotations() chartOption {
 	return func(opts *chartOptions) {
-		opts.Chart.Metadata.Annotations = map[string]string{
-			"hypper.cattle.io/namespace":     "hypper",
-			"hypper.cattle.io/release-name":  "my-hypper-name",
-			"catalog.cattle.io/namespace":    "fleet-system",
-			"catalog.cattle.io/release-name": "fleet",
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
 		}
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/namespace"] = "hypper"
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/release-name"] = "my-hypper-name"
 	}
 }
 
 func withFallbackAnnotations() chartOption {
 	return func(opts *chartOptions) {
-		opts.Chart.Metadata.Annotations = map[string]string{
-			"catalog.cattle.io/namespace":    "fleet-system",
-			"catalog.cattle.io/release-name": "fleet",
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
 		}
+		opts.Chart.Metadata.Annotations["catalog.cattle.io/namespace"] = "fleet-system"
+		opts.Chart.Metadata.Annotations["catalog.cattle.io/release-name"] = "fleet"
 	}
 }

--- a/pkg/action/dependency_shared.go
+++ b/pkg/action/dependency_shared.go
@@ -1,0 +1,227 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/gosuri/uitable"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+)
+
+// Dependency is the action for building a given chart's dependency tree.
+//
+// It provides the implementation of 'helm dependency' and its respective subcommands.
+type Dependency struct {
+	Verify      bool
+	Keyring     string
+	SkipRefresh bool
+}
+
+// NewDependency creates a new Dependency object with the given configuration.
+func NewDependency() *Dependency {
+	return &Dependency{}
+}
+
+// List executes 'helm dependency list'.
+func (d *Dependency) List(chartpath string, out io.Writer) error {
+	c, err := loader.Load(chartpath)
+	if err != nil {
+		return err
+	}
+
+	if c.Metadata.Dependencies == nil {
+		fmt.Fprintf(out, "WARNING: no dependencies at %s\n", filepath.Join(chartpath, "charts"))
+		return nil
+	}
+
+	d.printDependencies(chartpath, out, c)
+	fmt.Fprintln(out)
+	d.printMissing(chartpath, out, c.Metadata.Dependencies)
+	return nil
+}
+
+// dependecyStatus returns a string describing the status of a dependency viz a viz the parent chart.
+func (d *Dependency) dependencyStatus(chartpath string, dep *chart.Dependency, parent *chart.Chart) string {
+	filename := fmt.Sprintf("%s-%s.tgz", dep.Name, "*")
+
+	// If a chart is unpacked, this will check the unpacked chart's `charts/` directory for tarballs.
+	// Technically, this is COMPLETELY unnecessary, and should be removed in Helm 4. It is here
+	// to preserved backward compatibility. In Helm 2/3, there is a "difference" between
+	// the tgz version (which outputs "ok" if it unpacks) and the loaded version (which outouts
+	// "unpacked"). Early in Helm 2's history, this would have made a difference. But it no
+	// longer does. However, since this code shipped with Helm 3, the output must remain stable
+	// until Helm 4.
+	switch archives, err := filepath.Glob(filepath.Join(chartpath, "charts", filename)); {
+	case err != nil:
+		return "bad pattern"
+	case len(archives) > 1:
+		// See if the second part is a SemVer
+		found := []string{}
+		for _, arc := range archives {
+			// we need to trip the prefix dirs and the extension off.
+			filename = strings.TrimSuffix(filepath.Base(arc), ".tgz")
+			maybeVersion := strings.TrimPrefix(filename, fmt.Sprintf("%s-", dep.Name))
+
+			if _, err := semver.StrictNewVersion(maybeVersion); err == nil {
+				// If the version parsed without an error, it is possibly a valid
+				// version.
+				found = append(found, arc)
+			}
+		}
+
+		if l := len(found); l == 1 {
+			// If we get here, we do the same thing as in len(archives) == 1.
+			if r := statArchiveForStatus(found[0], dep); r != "" {
+				return r
+			}
+
+			// Fall through and look for directories
+		} else if l > 1 {
+			return "too many matches"
+		}
+
+		// The sanest thing to do here is to fall through and see if we have any directory
+		// matches.
+
+	case len(archives) == 1:
+		archive := archives[0]
+		if r := statArchiveForStatus(archive, dep); r != "" {
+			return r
+		}
+
+	}
+	// End unnecessary code.
+
+	var depChart *chart.Chart
+	for _, item := range parent.Dependencies() {
+		if item.Name() == dep.Name {
+			depChart = item
+		}
+	}
+
+	if depChart == nil {
+		return "missing"
+	}
+
+	if depChart.Metadata.Version != dep.Version {
+		constraint, err := semver.NewConstraint(dep.Version)
+		if err != nil {
+			return "invalid version"
+		}
+
+		v, err := semver.NewVersion(depChart.Metadata.Version)
+		if err != nil {
+			return "invalid version"
+		}
+
+		if !constraint.Check(v) {
+			return "wrong version"
+		}
+	}
+
+	return "unpacked"
+}
+
+// stat an archive and return a message if the stat is successful
+//
+// This is a refactor of the code originally in dependencyStatus. It is here to
+// support legacy behavior, and should be removed in Helm 4.
+func statArchiveForStatus(archive string, dep *chart.Dependency) string {
+	if _, err := os.Stat(archive); err == nil {
+		c, err := loader.Load(archive)
+		if err != nil {
+			return "corrupt"
+		}
+		if c.Name() != dep.Name {
+			return "misnamed"
+		}
+
+		if c.Metadata.Version != dep.Version {
+			constraint, err := semver.NewConstraint(dep.Version)
+			if err != nil {
+				return "invalid version"
+			}
+
+			v, err := semver.NewVersion(c.Metadata.Version)
+			if err != nil {
+				return "invalid version"
+			}
+
+			if !constraint.Check(v) {
+				return "wrong version"
+			}
+		}
+		return "ok"
+	}
+	return ""
+}
+
+// printDependencies prints all of the dependencies in the yaml file.
+func (d *Dependency) printDependencies(chartpath string, out io.Writer, c *chart.Chart) {
+	table := uitable.New()
+	table.MaxColWidth = 80
+	table.AddRow("NAME", "VERSION", "REPOSITORY", "STATUS")
+	for _, row := range c.Metadata.Dependencies {
+		table.AddRow(row.Name, row.Version, row.Repository, d.dependencyStatus(chartpath, row, c))
+	}
+	fmt.Fprintln(out, table)
+}
+
+// printMissing prints warnings about charts that are present on disk, but are
+// not in Charts.yaml.
+func (d *Dependency) printMissing(chartpath string, out io.Writer, reqs []*chart.Dependency) {
+	folder := filepath.Join(chartpath, "charts/*")
+	files, err := filepath.Glob(folder)
+	if err != nil {
+		fmt.Fprintln(out, err)
+		return
+	}
+
+	for _, f := range files {
+		fi, err := os.Stat(f)
+		if err != nil {
+			fmt.Fprintf(out, "Warning: %s\n", err)
+		}
+		// Skip anything that is not a directory and not a tgz file.
+		if !fi.IsDir() && filepath.Ext(f) != ".tgz" {
+			continue
+		}
+		c, err := loader.Load(f)
+		if err != nil {
+			fmt.Fprintf(out, "WARNING: %q is not a chart.\n", f)
+			continue
+		}
+		found := false
+		for _, d := range reqs {
+			if d.Name == c.Name() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Fprintf(out, "WARNING: %q is not in Chart.yaml.\n", f)
+		}
+	}
+}

--- a/pkg/action/dependency_shared_test.go
+++ b/pkg/action/dependency_shared_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Helm Authors.
+Copyright The Helm Authors, SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,144 +18,152 @@ package action
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"helm.sh/helm/v3/internal/test"
 	"helm.sh/helm/v3/pkg/chart"
-	"helm.sh/helm/v3/pkg/chartutil"
+	"helm.sh/helm/v3/pkg/release"
+
+	"github.com/Masterminds/log-go"
+	logcli "github.com/Masterminds/log-go/impl/cli"
+	"github.com/rancher-sandbox/hypper/internal/test"
 )
 
-func TestList(t *testing.T) {
+func newSharedDepFixture(t *testing.T, ns string) *SharedDependency {
+	sd := NewSharedDependency(actionConfigFixture(t))
+	sd.Namespace = ns
+	return sd
+}
+
+func TestSharedDepsList(t *testing.T) {
 	for _, tcase := range []struct {
-		chart  string
-		golden string
+		chart     string
+		golden    string
+		wantError bool
 	}{
 		{
-			chart:  "testdata/charts/chart-with-compressed-dependencies",
-			golden: "output/list-compressed-deps.txt",
+			chart:     "no/such/chart",
+			wantError: true,
 		},
 		{
-			chart:  "testdata/charts/chart-with-compressed-dependencies-2.1.8.tgz",
-			golden: "output/list-compressed-deps-tgz.txt",
+			chart:  "testdata/charts/vanilla-helm",
+			golden: "output/shared-deps-no-deps.txt",
 		},
 		{
-			chart:  "testdata/charts/chart-with-uncompressed-dependencies",
-			golden: "output/list-uncompressed-deps.txt",
+			chart:     "testdata/charts/shared-deps-malformed",
+			golden:    "output/shared-deps-malformed.txt",
+			wantError: true,
 		},
 		{
-			chart:  "testdata/charts/chart-with-uncompressed-dependencies-2.1.8.tgz",
-			golden: "output/list-uncompressed-deps-tgz.txt",
-		},
-		{
-			chart:  "testdata/charts/chart-missing-deps",
-			golden: "output/list-missing-deps.txt",
+			chart:  "testdata/charts/hypper-annot",
+			golden: "output/shared-deps-some-deps.txt",
 		},
 	} {
-		buf := bytes.Buffer{}
-		if err := NewDependency().List(tcase.chart, &buf); err != nil {
-			t.Fatal(err)
+		// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
+		buf := new(bytes.Buffer)
+		logger := logcli.NewStandard()
+		logger.InfoOut = buf
+		logger.WarnOut = buf
+		logger.ErrorOut = buf
+		log.Current = logger
+
+		sharedDepAction := newSharedDepFixture(t, "hypper")
+		err := sharedDepAction.List(tcase.chart, log.Current)
+		if (err != nil) != tcase.wantError {
+			t.Errorf("expected error, got '%v'", err)
 		}
-		test.AssertGoldenBytes(t, buf.Bytes(), tcase.golden)
+		if tcase.golden != "" {
+			test.AssertGoldenBytes(t, buf.Bytes(), tcase.golden)
+		}
 	}
 }
 
-// TestDependencyStatus_Dashes is a regression test to make sure that dashes in
-// chart names do not cause resolution problems.
-func TestDependencyStatus_Dashes(t *testing.T) {
-	// Make a temp dir
-	dir, err := ioutil.TempDir("", "helmtest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	chartpath := filepath.Join(dir, "charts")
-	if err := os.MkdirAll(chartpath, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	// Add some fake charts
-	first := buildChart(withName("first-chart"))
-	_, err = chartutil.Save(first, chartpath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	second := buildChart(withName("first-chart-second-chart"))
-	_, err = chartutil.Save(second, chartpath)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dep := &chart.Dependency{
-		Name:    "first-chart",
-		Version: "0.1.0",
-	}
-
-	// Now try to get the deps
-	stat := NewDependency().dependencyStatus(dir, dep, first)
-	if stat != "ok" {
-		t.Errorf("Unexpected status: %q", stat)
-	}
-}
-
-func TestStatArchiveForStatus(t *testing.T) {
-	// Make a temp dir
-	dir, err := ioutil.TempDir("", "helmtest-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
-	chartpath := filepath.Join(dir, "charts")
-	if err := os.MkdirAll(chartpath, 0700); err != nil {
-		t.Fatal(err)
-	}
-
-	// unsaved chart
-	lilith := buildChart(withName("lilith"))
-
-	// dep referring to chart
-	dep := &chart.Dependency{
-		Name:    "lilith",
-		Version: "1.2.3",
-	}
-
+func TestSharedDepsSetNamespace(t *testing.T) {
 	is := assert.New(t)
 
-	lilithpath := filepath.Join(chartpath, "lilith-1.2.3.tgz")
-	is.Empty(statArchiveForStatus(lilithpath, dep))
+	// chart without annotations
+	instAction := installAction(t)
+	chart := buildChart()
+	instAction.SetNamespace(chart, "defaultns")
+	is.Equal("defaultns", instAction.Namespace)
 
-	// save the chart (version 0.1.0, because that is the default)
-	where, err := chartutil.Save(lilith, chartpath)
-	is.NoError(err)
+	// hypper annotations have priority over fallback annotations
+	instAction = installAction(t)
+	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
+	instAction.SetNamespace(chart, "defaultns")
+	is.Equal("hypper", instAction.Namespace)
 
-	// Should get "wrong version" because we asked for 1.2.3 and got 0.1.0
-	is.Equal("wrong version", statArchiveForStatus(where, dep))
+	// fallback annotations have priority over default ns
+	instAction = installAction(t)
+	chart = buildChart(withFallbackAnnotations())
+	instAction.SetNamespace(chart, "defaultns")
+	is.Equal("fleet-system", instAction.Namespace)
+}
 
-	// Break version on dep
-	dep = &chart.Dependency{
-		Name:    "lilith",
-		Version: "1.2.3.4.5",
+func TestSharedDependencyStatus(t *testing.T) {
+	is := assert.New(t)
+
+	mk := func(name string, vers int, status release.Status, namespace string) *release.Release {
+		return release.Mock(&release.MockReleaseOptions{
+			Name:      name,
+			Version:   vers,
+			Status:    status,
+			Namespace: namespace,
+		})
 	}
-	is.Equal("invalid version", statArchiveForStatus(where, dep))
 
-	// Break the name
-	dep = &chart.Dependency{
-		Name:    "lilith2",
-		Version: "1.2.3",
+	// installed dep
+	sharedDepAction := newSharedDepFixture(t, "hypper")
+	dep := chart.Dependency{
+		Name:       "mariadb",
+		Version:    "10.5.9",
+		Repository: "https://another.example.com/charts",
 	}
-	is.Equal("misnamed", statArchiveForStatus(where, dep))
+	releases := []*release.Release{
+		mk("mariadb", 3, release.StatusDeployed, "hypper"),
+		mk("musketeers", 10, release.StatusSuperseded, "default"),
+		mk("musketeers", 9, release.StatusSuperseded, "default"),
+	}
+	is.Equal("deployed", sharedDepAction.SharedDependencyStatus(&dep, releases))
 
-	// Now create the right version
-	dep = &chart.Dependency{
-		Name:    "lilith",
-		Version: "0.1.0",
+	// print status of release matching dep
+	sharedDepAction = newSharedDepFixture(t, "hypper")
+	dep = chart.Dependency{
+		Name:       "mariadb",
+		Version:    "10.5.9",
+		Repository: "https://another.example.com/charts",
 	}
-	is.Equal("ok", statArchiveForStatus(where, dep))
+	releases = []*release.Release{
+		mk("mariadb", 3, release.StatusPendingInstall, "hypper"),
+	}
+	is.Equal("pending-install", sharedDepAction.SharedDependencyStatus(&dep, releases))
+
+	// not installed, but on the same ns
+	sharedDepAction = newSharedDepFixture(t, "hypper")
+	dep = chart.Dependency{
+		Name:       "mariadb",
+		Version:    "10.5.9",
+		Repository: "https://another.example.com/charts",
+	}
+	releases = []*release.Release{
+		mk("musketeers", 11, release.StatusDeployed, "hypper"),
+		mk("musketeers", 10, release.StatusSuperseded, "hypper"),
+		mk("carabins", 1, release.StatusSuperseded, "hypper"),
+	}
+	is.Equal("not-installed", sharedDepAction.SharedDependencyStatus(&dep, releases))
+
+	// installed, but in a different namespace
+	sharedDepAction = newSharedDepFixture(t, "other-ns")
+	dep = chart.Dependency{
+		Name:       "mariadb",
+		Version:    "10.5.9",
+		Repository: "https://another.example.com/charts",
+	}
+	releases = []*release.Release{
+		mk("mariadb", 11, release.StatusDeployed, "hypper"),
+		mk("musketeers", 10, release.StatusSuperseded, "hypper"),
+		mk("carabins", 1, release.StatusSuperseded, "hypper"),
+	}
+	is.Equal("not-installed", sharedDepAction.SharedDependencyStatus(&dep, releases))
+
 }

--- a/pkg/action/dependency_shared_test.go
+++ b/pkg/action/dependency_shared_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package action
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"helm.sh/helm/v3/internal/test"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+func TestList(t *testing.T) {
+	for _, tcase := range []struct {
+		chart  string
+		golden string
+	}{
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies",
+			golden: "output/list-compressed-deps.txt",
+		},
+		{
+			chart:  "testdata/charts/chart-with-compressed-dependencies-2.1.8.tgz",
+			golden: "output/list-compressed-deps-tgz.txt",
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies",
+			golden: "output/list-uncompressed-deps.txt",
+		},
+		{
+			chart:  "testdata/charts/chart-with-uncompressed-dependencies-2.1.8.tgz",
+			golden: "output/list-uncompressed-deps-tgz.txt",
+		},
+		{
+			chart:  "testdata/charts/chart-missing-deps",
+			golden: "output/list-missing-deps.txt",
+		},
+	} {
+		buf := bytes.Buffer{}
+		if err := NewDependency().List(tcase.chart, &buf); err != nil {
+			t.Fatal(err)
+		}
+		test.AssertGoldenBytes(t, buf.Bytes(), tcase.golden)
+	}
+}
+
+// TestDependencyStatus_Dashes is a regression test to make sure that dashes in
+// chart names do not cause resolution problems.
+func TestDependencyStatus_Dashes(t *testing.T) {
+	// Make a temp dir
+	dir, err := ioutil.TempDir("", "helmtest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	chartpath := filepath.Join(dir, "charts")
+	if err := os.MkdirAll(chartpath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add some fake charts
+	first := buildChart(withName("first-chart"))
+	_, err = chartutil.Save(first, chartpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	second := buildChart(withName("first-chart-second-chart"))
+	_, err = chartutil.Save(second, chartpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dep := &chart.Dependency{
+		Name:    "first-chart",
+		Version: "0.1.0",
+	}
+
+	// Now try to get the deps
+	stat := NewDependency().dependencyStatus(dir, dep, first)
+	if stat != "ok" {
+		t.Errorf("Unexpected status: %q", stat)
+	}
+}
+
+func TestStatArchiveForStatus(t *testing.T) {
+	// Make a temp dir
+	dir, err := ioutil.TempDir("", "helmtest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	chartpath := filepath.Join(dir, "charts")
+	if err := os.MkdirAll(chartpath, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// unsaved chart
+	lilith := buildChart(withName("lilith"))
+
+	// dep referring to chart
+	dep := &chart.Dependency{
+		Name:    "lilith",
+		Version: "1.2.3",
+	}
+
+	is := assert.New(t)
+
+	lilithpath := filepath.Join(chartpath, "lilith-1.2.3.tgz")
+	is.Empty(statArchiveForStatus(lilithpath, dep))
+
+	// save the chart (version 0.1.0, because that is the default)
+	where, err := chartutil.Save(lilith, chartpath)
+	is.NoError(err)
+
+	// Should get "wrong version" because we asked for 1.2.3 and got 0.1.0
+	is.Equal("wrong version", statArchiveForStatus(where, dep))
+
+	// Break version on dep
+	dep = &chart.Dependency{
+		Name:    "lilith",
+		Version: "1.2.3.4.5",
+	}
+	is.Equal("invalid version", statArchiveForStatus(where, dep))
+
+	// Break the name
+	dep = &chart.Dependency{
+		Name:    "lilith2",
+		Version: "1.2.3",
+	}
+	is.Equal("misnamed", statArchiveForStatus(where, dep))
+
+	// Now create the right version
+	dep = &chart.Dependency{
+		Name:    "lilith",
+		Version: "0.1.0",
+	}
+	is.Equal("ok", statArchiveForStatus(where, dep))
+}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -44,7 +44,7 @@ func TestSetNamespace(t *testing.T) {
 
 	// hypper annotations have priority over fallback annotations
 	instAction = installAction(t)
-	chart = buildChart(withHypperAnnotations())
+	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
 	instAction.SetNamespace(chart, "defaultns")
 	is.Equal("hypper", instAction.Namespace)
 
@@ -78,7 +78,7 @@ func TestName(t *testing.T) {
 
 	// hypper annotations have priority over fallback annotations
 	instAction = installAction(t)
-	chart = buildChart(withHypperAnnotations())
+	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
 	name, err = instAction.Name(chart, []string{"chart-uri"})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -33,7 +33,7 @@ func installAction(t *testing.T) *Install {
 	return instAction
 }
 
-func TestSetNamespace(t *testing.T) {
+func TestInstallSetNamespace(t *testing.T) {
 	is := assert.New(t)
 
 	// chart without annotations

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -25,7 +25,7 @@ type List struct {
 	cfg *Configuration
 }
 
-// NewList constructs a new *List by embedding action.List
+// NewList constructs a new *List by embedding helm/pkg/action.List
 func NewList(cfg *Configuration) *List {
 	return &List{
 		action.NewList(cfg.Configuration),

--- a/pkg/action/testdata/charts/hypper-annot/Chart.yaml
+++ b/pkg/action/testdata/charts/hypper-annot/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://helm.sh/helm
+name: empty
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+annotations:
+  hypper.cattle.io/namespace: hypper
+  hypper.cattle.io/release-name: my-hypper-name
+  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/release-name: fleet
+  hypper.cattle.io/shared-dependencies: |
+    - name: prometheus
+      version: "13.3.1"
+      repository: "https://example.com/charts"
+    - name: postgresql
+      version: "10.3.11"
+      repository: "https://another.example.com/charts"

--- a/pkg/action/testdata/charts/hypper-annot/README.md
+++ b/pkg/action/testdata/charts/hypper-annot/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/pkg/action/testdata/charts/hypper-annot/templates/empty.yaml
+++ b/pkg/action/testdata/charts/hypper-annot/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/pkg/action/testdata/charts/hypper-annot/values.yaml
+++ b/pkg/action/testdata/charts/hypper-annot/values.yaml
@@ -1,0 +1,1 @@
+Name: my-empty

--- a/pkg/action/testdata/charts/shared-deps-malformed/Chart.yaml
+++ b/pkg/action/testdata/charts/shared-deps-malformed/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://helm.sh/helm
+name: empty
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+annotations:
+  hypper.cattle.io/namespace: hypper
+  hypper.cattle.io/release-name: my-hypper-name
+  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/release-name: fleet
+  hypper.cattle.io/shared-dependencies: |
+    - name: prometheus
+      version: "13.3.1"
+      repository: "https://example.com/charts"
+      name: postgresql
+      version: "10.3.11"
+      repository: "https://another.example.com/charts"

--- a/pkg/action/testdata/charts/shared-deps-malformed/README.md
+++ b/pkg/action/testdata/charts/shared-deps-malformed/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/pkg/action/testdata/charts/shared-deps-malformed/templates/empty.yaml
+++ b/pkg/action/testdata/charts/shared-deps-malformed/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/pkg/action/testdata/charts/shared-deps-malformed/values.yaml
+++ b/pkg/action/testdata/charts/shared-deps-malformed/values.yaml
@@ -1,0 +1,1 @@
+Name: my-empty

--- a/pkg/action/testdata/charts/vanilla-helm/Chart.yaml
+++ b/pkg/action/testdata/charts/vanilla-helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://helm.sh/helm
+name: empty
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0

--- a/pkg/action/testdata/charts/vanilla-helm/README.md
+++ b/pkg/action/testdata/charts/vanilla-helm/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/pkg/action/testdata/charts/vanilla-helm/templates/empty.yaml
+++ b/pkg/action/testdata/charts/vanilla-helm/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/pkg/action/testdata/charts/vanilla-helm/values.yaml
+++ b/pkg/action/testdata/charts/vanilla-helm/values.yaml
@@ -1,0 +1,1 @@
+Name: my-empty

--- a/pkg/action/testdata/output/shared-deps-malformed.txt
+++ b/pkg/action/testdata/output/shared-deps-malformed.txt
@@ -1,0 +1,1 @@
+ERROR: Chart.yaml metadata is malformed for chart testdata/charts/shared-deps-malformed

--- a/pkg/action/testdata/output/shared-deps-no-deps.txt
+++ b/pkg/action/testdata/output/shared-deps-no-deps.txt
@@ -1,0 +1,1 @@
+WARNING: No shared dependencies in testdata/charts/vanilla-helm

--- a/pkg/action/testdata/output/shared-deps-some-deps.txt
+++ b/pkg/action/testdata/output/shared-deps-some-deps.txt
@@ -1,0 +1,3 @@
+NAME      	VERSION	REPOSITORY                        	STATUS       
+prometheus	13.3.1 	https://example.com/charts        	not-installed
+postgresql	10.3.11	https://another.example.com/charts	not-installed

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package action
 
 import (
@@ -22,6 +23,7 @@ import (
 	"strings"
 )
 
+// Upgrade is a composite type of Helm's Upgrade type
 type Upgrade struct {
 	*action.Upgrade
 	cfg         *Configuration


### PR DESCRIPTION
This PR Implements `hypper shared-dep list` command:
   ```
   $ hypper shared-dep list ~/suse/hypper/cmd/hypper/testdata/testcharts/hypper-annot
   NAME            VERSION REPOSITORY                              STATUS
   prometheus      13.3.1  https://example.com/charts              deployed
   postgresql      10.3.11 https://another.example.com/charts      not-installed
   ```
It does that by:
- Creating `pkg/action/dependency_shared{,_test}.go` and tests
- Creating `cmd/hypper/dependency_shared{,_test}.go` and tests

Partially implements https://github.com/rancher-sandbox/hypper/issues/30 (missing installing shared-deps when doing `hypper install`).


