### PR TITLE
Deterministic names

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -47,7 +47,7 @@ where the chart will be installed. By priority order:
 1. By the args passed from the CLI: hypper install mymaria example/mariadb -n system
 2. By using hypper.cattle.io annotations in the Chart.yaml
 3. By using catalog.cattle.io annotations in the Chart.yaml
-4. By using the current namespace as configured with the kubeconfig, or the flag --generate-name
+4. By using the chart name from the Chart.yaml if nothing else is specified
 `
 
 func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra.Command {
@@ -79,7 +79,6 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 }
 
 func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
-	f.BoolVarP(&client.GenerateName, "generate-name", "g", false, "generate the name (and omit the NAME parameter)")
 	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
 }
 

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -61,10 +61,9 @@ func TestInstallCmd(t *testing.T) {
 		},
 		// Install, no name or annotations specified
 		{
-			name:      "install, with no name or annot specified",
-			cmd:       "install testdata/testcharts/vanilla-helm",
-			golden:    "output/install-no-name-or-annot.txt",
-			wantError: true,
+			name:   "install, with no name or annot specified",
+			cmd:    "install testdata/testcharts/vanilla-helm",
+			golden: "output/install-no-name-or-annot.txt",
 		},
 	}
 	runTestActionCmd(t, tests)

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -53,10 +53,10 @@ func TestInstallCmd(t *testing.T) {
 			cmd:    "install testdata/testcharts/fallback-annot",
 			golden: "output/install-fallback-annot.txt",
 		},
-		// Install, annotations have priority over generate-name
+		// Install, annotations have priority over default name from Chart.yml
 		{
-			name:   "install, annot have priority over generate-name",
-			cmd:    "install testdata/testcharts/hypper-annot --generate-name",
+			name:   "install, annot have priority over default name from Chart.yml",
+			cmd:    "install testdata/testcharts/hypper-annot",
 			golden: "output/install-hypper-annot.txt",
 		},
 		// Install, no name or annotations specified

--- a/cmd/hypper/testdata/output/install-no-name-or-annot.txt
+++ b/cmd/hypper/testdata/output/install-no-name-or-annot.txt
@@ -1,1 +1,2 @@
-Error: must either provide a name, set the correct chart annotations, or specify --generate-name
+Installing chart "empty" in namespace "default"…
+Done! 👏 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -124,7 +124,7 @@ func (i *Install) Name(chart *chart.Chart, args []string) (string, error) {
 	}
 
 	if !i.GenerateName {
-		return "", errors.New("must either provide a name, set the correct chart annotations, or specify --generate-name")
+		return chart.Name(), nil
 	}
 
 	base := filepath.Base(args[0])

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -17,9 +17,6 @@ limitations under the License.
 package action
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"strings"
 
 	"github.com/pkg/errors"
@@ -28,7 +25,6 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
-	"helm.sh/helm/v3/pkg/time"
 )
 
 // Install is a composite type of Helm's Install type
@@ -88,9 +84,6 @@ func (i *Install) Name(chart *chart.Chart, args []string) (string, error) {
 	// cobra flags have been already stripped
 
 	flagsNotSet := func() error {
-		if i.GenerateName {
-			return errors.New("cannot set --generate-name and also specify a name")
-		}
 		if i.NameTemplate != "" {
 			return errors.New("cannot set --name-template and also specify a name")
 		}
@@ -123,20 +116,8 @@ func (i *Install) Name(chart *chart.Chart, args []string) (string, error) {
 		return i.ReleaseName, nil
 	}
 
-	if !i.GenerateName {
-		return chart.Name(), nil
-	}
+	return chart.Name(), nil
 
-	base := filepath.Base(args[0])
-	if base == "." || base == "" {
-		base = "chart"
-	}
-	// if present, strip out the file extension from the name
-	if idx := strings.Index(base, "."); idx != -1 {
-		base = base[0:idx]
-	}
-
-	return fmt.Sprintf("%s-%d", base, time.Now().Unix()), nil
 }
 
 // Chart returns the chart that should be used.

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -106,11 +106,11 @@ func TestName(t *testing.T) {
 	instAction = installAction(t)
 	instAction.ReleaseName = ""
 	chart = buildChart()
-	_, err = instAction.Name(chart, []string{"chart-uri"})
+	name, err = instAction.Name(chart, []string{"chart-uri"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	is.Equal("fleet", name)
+	is.Equal("hello", name)
 }
 
 func TestChart(t *testing.T) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -119,10 +119,10 @@ func TestName(t *testing.T) {
 	instAction.ReleaseName = ""
 	chart = buildChart()
 	_, err = instAction.Name(chart, []string{"chart-uri"})
-	if err == nil {
-		t.Fatal("expected an error")
+	if err != nil {
+		t.Fatal(err)
 	}
-	is.Equal("must either provide a name, set the correct chart annotations, or specify --generate-name", err.Error())
+	is.Equal("fleet", name)
 }
 
 func TestNameGenerateName(t *testing.T) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package action
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"helm.sh/helm/v3/pkg/time"
 )
 
 func installAction(t *testing.T) *Install {
@@ -104,16 +102,6 @@ func TestName(t *testing.T) {
 	}
 	is.Equal("fleet", name)
 
-	// --generate-name while specifying a name
-	instAction = installAction(t)
-	instAction.GenerateName = true
-	chart = buildChart()
-	_, err = instAction.Name(chart, []string{"name1", "chart-uri"})
-	if err == nil {
-		t.Fatal(err)
-	}
-	is.Equal("cannot set --generate-name and also specify a name", err.Error())
-
 	// no name or annotations present
 	instAction = installAction(t)
 	instAction.ReleaseName = ""
@@ -123,66 +111,6 @@ func TestName(t *testing.T) {
 		t.Fatal(err)
 	}
 	is.Equal("fleet", name)
-}
-
-func TestNameGenerateName(t *testing.T) {
-	is := assert.New(t)
-	instAction := installAction(t)
-
-	instAction.ReleaseName = ""
-	instAction.GenerateName = true
-	chart := buildChart()
-
-	tests := []struct {
-		Name         string
-		Chart        string
-		ExpectedName string
-	}{
-		{
-			"local filepath",
-			"./chart",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-		{
-			"dot filepath",
-			".",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-		{
-			"empty filepath",
-			"",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-		{
-			"packaged chart",
-			"chart.tgz",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-		{
-			"packaged chart with .tar.gz extension",
-			"chart.tar.gz",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-		{
-			"packaged chart with local extension",
-			"./chart.tgz",
-			fmt.Sprintf("chart-%d", time.Now().Unix()),
-		},
-	}
-
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
-			name, err := instAction.Name(chart, []string{tc.Chart})
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			is.Equal(tc.ExpectedName, name)
-		})
-	}
 }
 
 func TestChart(t *testing.T) {


### PR DESCRIPTION
This PR removes the `--generate-name` flag, if now chart name is provided (either through annotations or cli) it will use the name from the `Chart.yaml` out of the chart itself.