### PR TITLE
Set the client namespace on uninstall

### DIFF
--- a/cmd/hypper/uninstall.go
+++ b/cmd/hypper/uninstall.go
@@ -40,6 +40,7 @@ func newUninstallCmd(actionConfig *action.Configuration, logger log.Logger) *cob
 		RunE: func(cmd *cobra.Command, args []string) error {
 			for i := 0; i < len(args); i++ {
 				logger.Info(eyecandy.ESPrintf(settings.NoEmojis, ":fire: uninstalling %s", args[i]))
+				client.Config.SetNamespace(settings.Namespace())
 				res, err := client.Run(args[i])
 				if err != nil {
 					return err

--- a/pkg/action/uninstall.go
+++ b/pkg/action/uninstall.go
@@ -22,11 +22,13 @@ import (
 // Uninstall is a composite type of Helm's Uninstall type
 type Uninstall struct {
 	*action.Uninstall
+	Config *Configuration
 }
 
 // NewUninstall creates a new Uninstall by embedding action.Uninstall
 func NewUninstall(cfg *Configuration) *Uninstall {
 	return &Uninstall{
 		action.NewUninstall(cfg.Configuration),
+		cfg,
 	}
 }


### PR DESCRIPTION
We are missing reading from the chart annotations as well,
or maybe thats not gonna be implemented?

We are missing this piece to be able to clean up the resources properly but probably missing obtaining the namespace from annotattions which is quite bigger....and would probably benefit from extraction some generic methods...

Partial fix: #77 

Signed-off-by: Itxaka <igarcia@suse.com>