### PR TITLE
Introduce common methods for setNamespace and Name

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -116,13 +116,8 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		return nil, err
 	}
 
-	if settings.NamespaceFromFlag {
-		client.Namespace = settings.Namespace()
-	} else {
-		client.SetNamespace(chartRequested, settings.Namespace())
-	}
-
-	client.Config.SetNamespace(client.Namespace)
+	// Set namespace for the install client
+	action.SetNamespace(client, chartRequested, settings.Namespace(), settings.NamespaceFromFlag)
 
 	name, err := client.Name(chartRequested, args)
 	if err != nil {

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -119,11 +119,12 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	// Set namespace for the install client
 	action.SetNamespace(client, chartRequested, settings.Namespace(), settings.NamespaceFromFlag)
 
-	name, err := client.Name(chartRequested, args)
-	if err != nil {
-		return nil, err
+	if client.ReleaseName == "" {
+		client.ReleaseName, err = action.GetName(chartRequested, client.NameTemplate, args...)
+		if err != nil {
+			return nil, err
+		}
 	}
-	client.ReleaseName = name
 
 	if err := checkIfInstallable(chartRequested); err != nil {
 		return nil, err

--- a/cmd/hypper/upgrade.go
+++ b/cmd/hypper/upgrade.go
@@ -106,7 +106,10 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 
 			}
 			if client.ReleaseName == "" {
-				client.ReleaseName, _ = client.Name(ch)
+				client.ReleaseName, err = action.GetName(ch, "")
+				if err != nil {
+					return err
+				}
 				logger.Debugf("client.ReleaseName was empty, setting release name to %s", client.ReleaseName)
 			}
 

--- a/cmd/hypper/upgrade.go
+++ b/cmd/hypper/upgrade.go
@@ -123,13 +123,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 					}
 					instClient := action.NewInstall(cfg)
 					// Set namespace for the install client
-					if settings.NamespaceFromFlag {
-						instClient.Namespace = settings.Namespace()
-					} else {
-						instClient.SetNamespace(ch, settings.Namespace())
-					}
-					// By this time client.Namespace has the correct namespace
-					instClient.Config.SetNamespace(instClient.Namespace)
+					action.SetNamespace(client, ch, settings.Namespace(), settings.NamespaceFromFlag)
 
 					instClient.CreateNamespace = createNamespace
 					instClient.ChartPathOptions = client.ChartPathOptions
@@ -167,16 +161,8 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 			if err != nil {
 				return err
 			}
-
 			// Set namespace for the upgrade client
-			if settings.NamespaceFromFlag {
-				client.Namespace = settings.Namespace()
-			} else {
-				client.SetNamespace(ch, settings.Namespace())
-			}
-
-			// By this time client.Namespace has the correct namespace, so set it to the storage
-			client.Config.SetNamespace(client.Namespace)
+			action.SetNamespace(client, ch, settings.Namespace(), settings.NamespaceFromFlag)
 
 			rel, err := client.Run(client.ReleaseName, ch, vals)
 			if err != nil {

--- a/pkg/action/dependency_shared_test.go
+++ b/pkg/action/dependency_shared_test.go
@@ -84,19 +84,19 @@ func TestSharedDepsSetNamespace(t *testing.T) {
 	// chart without annotations
 	instAction := installAction(t)
 	chart := buildChart()
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("defaultns", instAction.Namespace)
 
 	// hypper annotations have priority over fallback annotations
 	instAction = installAction(t)
 	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("hypper", instAction.Namespace)
 
 	// fallback annotations have priority over default ns
 	instAction = installAction(t)
 	chart = buildChart(withFallbackAnnotations())
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("fleet-system", instAction.Namespace)
 }
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -60,22 +60,6 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	return rel, err
 }
 
-// SetNamespace sets the Namespace that should be used in action.Install
-//
-// This will read the chart annotations. If no annotations, it leave the existing ns in the action.
-func (i *Install) SetNamespace(chart *chart.Chart, defaultns string) {
-	i.Namespace = defaultns
-	if chart.Metadata.Annotations != nil {
-		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/namespace"]; ok {
-			i.Namespace = val
-		} else {
-			if val, ok := chart.Metadata.Annotations["catalog.cattle.io/namespace"]; ok {
-				i.Namespace = val
-			}
-		}
-	}
-}
-
 // Name returns the name that should be used.
 //
 // This will read the flags and handle name generation if necessary.

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -60,50 +60,6 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.
 	return rel, err
 }
 
-// Name returns the name that should be used.
-//
-// This will read the flags and handle name generation if necessary.
-func (i *Install) Name(chart *chart.Chart, args []string) (string, error) {
-	// args here will only be: [NAME] [CHART]
-	// cobra flags have been already stripped
-
-	flagsNotSet := func() error {
-		if i.NameTemplate != "" {
-			return errors.New("cannot set --name-template and also specify a name")
-		}
-		return nil
-	}
-
-	if len(args) > 2 {
-		return args[0], errors.Errorf("expected at most two arguments, unexpected arguments: %v", strings.Join(args[2:], ", "))
-	}
-
-	if len(args) == 2 {
-		return args[0], flagsNotSet()
-	}
-
-	if chart.Metadata.Annotations != nil {
-		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/release-name"]; ok {
-			return val, nil
-		}
-		if val, ok := chart.Metadata.Annotations["catalog.cattle.io/release-name"]; ok {
-			return val, nil
-		}
-	}
-
-	if i.NameTemplate != "" {
-		name, err := action.TemplateName(i.NameTemplate)
-		return name, err
-	}
-
-	if i.ReleaseName != "" {
-		return i.ReleaseName, nil
-	}
-
-	return chart.Name(), nil
-
-}
-
 // Chart returns the chart that should be used.
 //
 // This will read the flags and skip args if necessary.

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -37,19 +37,19 @@ func TestInstallSetNamespace(t *testing.T) {
 	// chart without annotations
 	instAction := installAction(t)
 	chart := buildChart()
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("defaultns", instAction.Namespace)
 
 	// hypper annotations have priority over fallback annotations
 	instAction = installAction(t)
 	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("hypper", instAction.Namespace)
 
 	// fallback annotations have priority over default ns
 	instAction = installAction(t)
 	chart = buildChart(withFallbackAnnotations())
-	instAction.SetNamespace(chart, "defaultns")
+	SetNamespace(instAction, chart, "defaultns", false)
 	is.Equal("fleet-system", instAction.Namespace)
 }
 

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -57,56 +57,40 @@ func TestName(t *testing.T) {
 	is := assert.New(t)
 
 	// too many args
-	instAction := installAction(t)
 	chart := buildChart()
-	_, err := instAction.Name(chart, []string{"name1", "chart-uri", "extraneous-arg"})
+	_, err := GetName(chart, "", "name1", "chart-uri", "extraneous-arg")
 	if err == nil {
 		t.Fatal("expected an error")
 	}
 	is.Equal("expected at most two arguments, unexpected arguments: extraneous-arg", err.Error())
 
 	// name and chart as args
-	instAction = installAction(t)
 	chart = buildChart()
-	name, err := instAction.Name(chart, []string{"name1", "chart-uri"})
+	name, err := GetName(chart, "", "name1", "chart-uri")
 	if err != nil {
 		t.Fatal(err)
 	}
 	is.Equal("name1", name)
 
 	// hypper annotations have priority over fallback annotations
-	instAction = installAction(t)
 	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	name, err = instAction.Name(chart, []string{"chart-uri"})
+	name, err = GetName(chart, "", "chart-uri")
 	if err != nil {
 		t.Fatal(err)
 	}
 	is.Equal("my-hypper-name", name)
 
 	// fallback annotations
-	instAction = installAction(t)
 	chart = buildChart(withFallbackAnnotations())
-	name, err = instAction.Name(chart, []string{"chart-uri"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	is.Equal("fleet", name)
-
-	// annotations have priority over generate-name
-	instAction = installAction(t)
-	instAction.GenerateName = true
-	chart = buildChart(withFallbackAnnotations())
-	name, err = instAction.Name(chart, []string{"chart-uri"})
+	name, err = GetName(chart, "", "chart-uri")
 	if err != nil {
 		t.Fatal(err)
 	}
 	is.Equal("fleet", name)
 
 	// no name or annotations present
-	instAction = installAction(t)
-	instAction.ReleaseName = ""
 	chart = buildChart()
-	name, err = instAction.Name(chart, []string{"chart-uri"})
+	name, err = GetName(chart, "", "chart-uri")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/upgrade.go
+++ b/pkg/action/upgrade.go
@@ -18,7 +18,6 @@ package action
 
 import (
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/chart"
 )
 
 // Upgrade is a composite type of Helm's Upgrade type
@@ -33,37 +32,5 @@ func NewUpgrade(cfg *Configuration) *Upgrade {
 	return &Upgrade{
 		Upgrade: action.NewUpgrade(cfg.Configuration),
 		Config:  cfg,
-	}
-}
-
-// Name returns the name that should be used.
-func (i *Upgrade) Name(chart *chart.Chart) (string, error) {
-	// args here will only be: [CHART]
-	if chart.Metadata.Annotations != nil {
-		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/release-name"]; ok {
-			return val, nil
-		}
-		if val, ok := chart.Metadata.Annotations["catalog.cattle.io/release-name"]; ok {
-			return val, nil
-		}
-	}
-
-	// If we dont have our annotations then return the base name
-	return chart.Metadata.Name, nil
-}
-
-// SetNamespace sets the Namespace that should be used in action.Upgrade
-//
-// This will read the chart annotations. If no annotations, it leave the existing ns in the action.
-func (i *Upgrade) SetNamespace(chart *chart.Chart, defaultns string) {
-	i.Namespace = defaultns
-	if chart.Metadata.Annotations != nil {
-		if val, ok := chart.Metadata.Annotations["hypper.cattle.io/namespace"]; ok {
-			i.Namespace = val
-		} else {
-			if val, ok := chart.Metadata.Annotations["catalog.cattle.io/namespace"]; ok {
-				i.Namespace = val
-			}
-		}
 	}
 }

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -32,19 +32,19 @@ func TestUpgradeSetNamespace(t *testing.T) {
 	// chart without annotations
 	upgrAction := upgradeAction(t)
 	chart := buildChart()
-	upgrAction.SetNamespace(chart, "defaultns")
+	SetNamespace(upgrAction, chart, "defaultns", false)
 	is.Equal("defaultns", upgrAction.Namespace)
 
 	// hypper annotations have priority over fallback annotations
 	upgrAction = upgradeAction(t)
 	chart = buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	upgrAction.SetNamespace(chart, "defaultns")
+	SetNamespace(upgrAction, chart, "defaultns", false)
 	is.Equal("hypper", upgrAction.Namespace)
 
 	// fallback annotations have priority over default ns
 	upgrAction = upgradeAction(t)
 	chart = buildChart(withFallbackAnnotations())
-	upgrAction.SetNamespace(chart, "defaultns")
+	SetNamespace(upgrAction, chart, "defaultns", false)
 	is.Equal("fleet-system", upgrAction.Namespace)
 }
 
@@ -52,27 +52,24 @@ func TestUpgradeName(t *testing.T) {
 	is := assert.New(t)
 
 	// hypper annotations have priority over fallback annotations
-	upgrAction := upgradeAction(t)
 	chart := buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	name, err := upgrAction.Name(chart)
+	name, err := GetName(chart, "", make([]string, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
 	is.Equal("my-hypper-name", name)
 
 	// fallback annotations
-	upgrAction = upgradeAction(t)
 	chart = buildChart(withFallbackAnnotations())
-	name, err = upgrAction.Name(chart)
+	name, err = GetName(chart, "", make([]string, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
 	is.Equal("fleet", name)
 
 	// no annotations should default to the chart name
-	upgrAction = upgradeAction(t)
 	chart = buildChart()
-	name, err = upgrAction.Name(chart)
+	name, err = GetName(chart, "", make([]string, 0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/upgrade_test.go
+++ b/pkg/action/upgrade_test.go
@@ -53,7 +53,7 @@ func TestUpgradeName(t *testing.T) {
 
 	// hypper annotations have priority over fallback annotations
 	chart := buildChart(withHypperAnnotations(), withFallbackAnnotations())
-	name, err := GetName(chart, "", make([]string, 0))
+	name, err := GetName(chart, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestUpgradeName(t *testing.T) {
 
 	// fallback annotations
 	chart = buildChart(withFallbackAnnotations())
-	name, err = GetName(chart, "", make([]string, 0))
+	name, err = GetName(chart, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +69,7 @@ func TestUpgradeName(t *testing.T) {
 
 	// no annotations should default to the chart name
 	chart = buildChart()
-	name, err = GetName(chart, "", make([]string, 0))
+	name, err = GetName(chart, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/action/utils.go
+++ b/pkg/action/utils.go
@@ -1,0 +1,54 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package action
+
+import (
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// SetNamespace sets the Namespace that should be used based on annotations or fallback to default
+// both on the action and on the storage.
+// if setDefault is true then it will just set the default namespace
+// This will read the chart annotations. If no annotations, it leave the existing ns in the action.
+// targetNS can be either the default namesapce (usually "default") or the namespace passed via
+// cli flag
+func SetNamespace(x interface{}, chart *chart.Chart, targetNS string, NamespaceFromFlag bool) {
+	namespace := targetNS
+	// NamespaceFromFlag is mainly used when we set the namespace via the cli flag --namespace
+	// and it has priority over everything else
+	if NamespaceFromFlag {
+		namespace = targetNS
+	} else {
+		if chart.Metadata.Annotations != nil {
+			if val, ok := chart.Metadata.Annotations["hypper.cattle.io/namespace"]; ok {
+				namespace = val
+			} else {
+				if val, ok := chart.Metadata.Annotations["catalog.cattle.io/namespace"]; ok {
+					namespace = val
+				}
+			}
+		}
+	}
+
+	switch i := x.(type) {
+	case *Install:
+		i.Namespace = namespace
+		i.Config.SetNamespace(namespace)
+	case *Upgrade:
+		i.Namespace = namespace
+		i.Config.SetNamespace(namespace)
+	}
+}


### PR DESCRIPTION
As both install and upgrade are using the action.SetNamespace
method, this extracts that method into a different file and
decouples it from the action so its easier to share and reuse

At the same time expands the method so it checks for the
NamespaceFromFlag and sets the client.Config storage
driver to the same namespace as the client in one go,
so we dont have to call multiple places for a namespace change

Signed-off-by: Itxaka <igarcia@suse.com>