### PR TITLE
Use relative path for bin dir in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-BINDIR	:= $(CURDIR)/bin
+BINDIR	:= bin/
 ifeq ($(OS),Windows_NT)
-	BINNAME	?= "hypper.exe"
+	BINNAME	?= hypper.exe
 else
-	BINNAME	?= "hypper"
+	BINNAME	?= hypper
 endif
 INSTALL_PATH ?= /usr/local/bin
 
@@ -34,17 +34,17 @@ endif
 all: build
 
 .PHONY: build
-build: lint $(BINDIR)/$(BINNAME)
+build: lint $(BINDIR)$(BINNAME)
 
 # Rebuild the binary if any of these files change
 SRC := $(shell find . -type f -name '*.go' -print) go.mod go.sum
 
-$(BINDIR)/$(BINNAME): $(SRC)
-	go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o '$(BINDIR)'/$(BINNAME) ./cmd/hypper
+$(BINDIR)$(BINNAME): $(SRC)
+	go build $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $(BINDIR)$(BINNAME) ./cmd/hypper
 
 .PHONY: install
 install: build
-	@install "$(BINDIR)/$(BINNAME)" "$(INSTALL_PATH)/$(BINNAME)"
+	@install "$(BINDIR)$(BINNAME)" "$(INSTALL_PATH)/$(BINNAME)"
 
 .PHONY: test
 test: lint build
@@ -91,5 +91,5 @@ license-check:
 
 .PHONY: clean
 clean:
-	rm $(BINDIR)/$(BINNAME)
+	rm $(BINDIR)$(BINNAME)
 	rmdir $(BINDIR)


### PR DESCRIPTION
This is to fix a case in which we build hypper on windows
based of the windows golang binary who is aware of the full
windows path, from a POSIX env like cygwin which is unaware
that is running on windows and uses a "fake" disk paths.

The result is that building the output ends up in the disk
drive that go runs out from + output path while rm tries to
clean the "fake" output path only

By using the relative path for building the binary we
avoid any mangling issues.

As a side effect this also removes the binary quotes that
were added for no discernible reason and while they didnt
affect anything AFAIK, they looked terrible.

Fixes: #41 

Signed-off-by: Itxaka <igarcia@suse.com>