### PR TITLE
Drop "Merge pull request" from changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,3 +37,4 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+      - '^Merge pull request'


### PR DESCRIPTION
Due to github merge defaults we usually get this
extra messages on the commit history of the repo.

They are kind of extra as they provide no info in
the changelog, so lets just exclude those from
appearing in the changelog.

Signed-off-by: Itxaka <igarcia@suse.com>