### PR TITLE
Enhance version set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ INSTALL_PATH ?= /usr/local/bin
 SHELL      = /usr/bin/env bash
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
-GIT_TAG    = $(shell git describe --tags --abbrev=0 --exact-match 2>/dev/null)
+ifneq ($(GIT_TAG),)
+	GIT_TAG := $(GIT_TAG)
+else
+	GIT_TAG = $(shell git describe --tags 2>/dev/null)
+endif
 
 # go option
 PKG        := ./...


### PR DESCRIPTION
    If we dont have a tag for the current commit
    the makefile will set the version to an empty
    value. While that is kind of ok, as there is no
    version attached to that, I think setting it
    to last_tag+version+short_commit is nicer
    
    With the patch we also allow to use a GIT_TAG
    env var already, useful to build specific or
    custom versions

Signed-off-by: Itxaka <igarcia@suse.com>