### PR TITLE
Catch unknown type in SetNamespace

### DIFF
--- a/pkg/action/utils.go
+++ b/pkg/action/utils.go
@@ -16,10 +16,12 @@ limitations under the License.
 package action
 
 import (
+	"strings"
+
+	"github.com/Masterminds/log-go"
 	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
-	"strings"
 )
 
 // SetNamespace sets the Namespace that should be used based on annotations or fallback to default
@@ -53,6 +55,11 @@ func SetNamespace(x interface{}, chart *chart.Chart, targetNS string, setDefault
 	case *Upgrade:
 		i.Namespace = namespace
 		i.Config.SetNamespace(namespace)
+	default:
+		// No namespace was set because the type was unknown to set the
+		// namespace on. This is an error in the use of the function in the
+		// source so a panic is thrown.
+		log.Panic("SetNamespace called on unknown type")
 	}
 }
 

--- a/pkg/action/utils_test.go
+++ b/pkg/action/utils_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright SUSE LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetNamespace(t *testing.T) {
+	// SetNamespace is tested in the install/upgrade tests. What is not tested
+	// is the case where a struct it can't set the namespace for is handled.
+	assert.Panics(t, func() {
+		act := &nmspc{}
+		chart := buildChart()
+		SetNamespace(act, chart, "defaultns", false)
+	})
+}
+
+type nmspc struct{}


### PR DESCRIPTION
This change adds a default switch to SetNamespace to handle the
situation of a type it does not know how to deal with. This will
catch a use of the function in a situation it does not know how
to deal with.