### PR TITLE
Add search command

### DIFF
--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -53,6 +53,7 @@ func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []st
 		newSharedDependencyCmd(actionConfig, logger),
 		newVersionCmd(logger),
 		newLintCmd(logger),
+		newSearchCmd(logger),
 	)
 
 	flags.ParseErrorsWhitelist.UnknownFlags = true

--- a/cmd/hypper/search.go
+++ b/cmd/hypper/search.go
@@ -1,0 +1,92 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/Masterminds/log-go"
+	"github.com/rancher-sandbox/hypper/pkg/search"
+	"github.com/spf13/cobra"
+)
+
+const searchDesc = `
+Search provides the ability to search for Hypper charts in the various places
+they can be stored including repositories you have added.
+Use search subcommands to search different locations for charts.
+`
+
+const searchRepoDesc = `
+Search reads through all of the repositories configured on the system, and
+looks for matches. Search of these repositories uses the metadata stored on
+the system.
+
+It will display the latest stable versions of the charts found. If you
+specify the --devel flag, the output will include pre-release versions.
+If you want to search using a version constraint, use --version.
+
+Examples:
+
+    # Search for stable release versions matching the keyword "nginx"
+    $ hypper search repo nginx
+
+    # Search for release versions matching the keyword "nginx", including pre-release versions
+    $ hypper search repo nginx --devel
+
+    # Search for the latest stable release for nginx-ingress with a major version of 1
+    $ hypper search repo nginx-ingress --version ^1.0.0
+
+Repositories are managed with 'hypper repo' commands.
+`
+
+// newSearchCmd is the generic search command that can contain subcommands
+func newSearchCmd(logger log.Logger) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "search [keyword]",
+		Short: "search for a keyword in charts",
+		Long:  searchDesc,
+	}
+
+	cmd.AddCommand(newSearchRepoCmd(logger))
+
+	return cmd
+}
+
+// newSearchRepoCmd search on repos
+func newSearchRepoCmd(logger log.Logger) *cobra.Command {
+	o := &search.RepoOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "repo [keyword]",
+		Short: "search repositories for a keyword in charts",
+		Long:  searchRepoDesc,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.RepoFile = settings.RepositoryConfig
+			o.RepoCacheDir = settings.RepositoryCache
+			return o.Run(logger, args)
+		},
+	}
+
+	f := cmd.Flags()
+	f.BoolVarP(&o.Regexp, "regexp", "r", false, "use regular expressions for searching repositories you have added")
+	f.BoolVarP(&o.Versions, "versions", "l", false, "show the long listing, with each version of each chart on its own line, for repositories you have added")
+	f.BoolVar(&o.Devel, "devel", false, "use development versions (alpha, beta, and release candidate releases), too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
+	f.StringVar(&o.Version, "version", "", "search using semantic versioning constraints on repositories you have added")
+	f.UintVar(&o.MaxColWidth, "max-col-width", 50, "maximum column width for output table")
+	bindOutputFlag(cmd, &o.OutputFormat)
+
+	return cmd
+}

--- a/cmd/hypper/search_test.go
+++ b/cmd/hypper/search_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright The Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+)
+
+func TestSearchRepositoriesCmd(t *testing.T) {
+	repoFile := "testdata/hypperhome/hypper/repositories.yaml"
+	repoCache := "testdata/hypperhome/hypper/repository"
+
+	tests := []cmdTestCase{{
+		name:   "search for 'alpine', expect one match with latest stable version",
+		cmd:    "search repo alpine",
+		golden: "output/search-multiple-stable-release.txt",
+	}, {
+		name:   "search for 'alpine', expect one match with newest development version",
+		cmd:    "search repo alpine --devel",
+		golden: "output/search-multiple-devel-release.txt",
+	}, {
+		name:   "search for 'alpine' with versions, expect three matches",
+		cmd:    "search repo alpine --versions",
+		golden: "output/search-multiple-versions.txt",
+	}, {
+		name:   "search for 'alpine' with version constraint, expect one match with version 0.1.0",
+		cmd:    "search repo alpine --version '>= 0.1, < 0.2'",
+		golden: "output/search-constraint.txt",
+	}, {
+		name:   "search for 'alpine' with version constraint, expect one match with version 0.1.0",
+		cmd:    "search repo alpine --versions --version '>= 0.1, < 0.2'",
+		golden: "output/search-versions-constraint.txt",
+	}, {
+		name:   "search for 'alpine' with version constraint, expect one match with version 0.2.0",
+		cmd:    "search repo alpine --version '>= 0.1'",
+		golden: "output/search-constraint-single.txt",
+	}, {
+		name:   "search for 'alpine' with version constraint and --versions, expect two matches",
+		cmd:    "search repo alpine --versions --version '>= 0.1'",
+		golden: "output/search-multiple-versions-constraints.txt",
+	}, {
+		name:   "search for 'syzygy', expect no matches",
+		cmd:    "search repo syzygy",
+		golden: "output/search-not-found.txt",
+	}, {
+		name:   "search for 'alp[a-z]+', expect two matches",
+		cmd:    "search repo alp[a-z]+ --regexp",
+		golden: "output/search-regex.txt",
+	}, {
+		name:      "search for 'alp[', expect failure to compile regexp",
+		cmd:       "search repo alp[ --regexp",
+		wantError: true,
+	}, {
+		name:   "search for 'maria', expect valid json output",
+		cmd:    "search repo maria --output json",
+		golden: "output/search-output-json.txt",
+	}, {
+		name:   "search for 'alpine', expect valid yaml output",
+		cmd:    "search repo alpine --output yaml",
+		golden: "output/search-output-yaml.txt",
+	}}
+
+	settings.Debug = true
+	defer func() { settings.Debug = false }()
+
+	for i := range tests {
+		tests[i].cmd += " --repository-config " + repoFile
+		tests[i].cmd += " --repository-cache " + repoCache
+	}
+	runTestCmd(t, tests)
+}

--- a/cmd/hypper/testdata/hypperhome/hypper/repositories.yaml
+++ b/cmd/hypper/testdata/hypperhome/hypper/repositories.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+generated: 2016-10-03T16:03:10.640376913-06:00
+repositories:
+- cache: testing-index.yaml
+  name: testing
+  url: http://example.com/charts

--- a/cmd/hypper/testdata/hypperhome/hypper/repository/test-name-index.yaml
+++ b/cmd/hypper/testdata/hypperhome/hypper/repository/test-name-index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries: {}
+generated: "2020-09-09T19:50:50.198347916-04:00"

--- a/cmd/hypper/testdata/hypperhome/hypper/repository/testing-index.yaml
+++ b/cmd/hypper/testdata/hypperhome/hypper/repository/testing-index.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+entries:
+  alpine:
+    - name: alpine
+      url: https://charts.helm.sh/stable/alpine-0.1.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      created: "2018-06-27T10:00:18.230700509Z"
+      deprecated: true
+      home: https://helm.sh/helm
+      sources:
+        - https://github.com/helm/helm
+      version: 0.1.0
+      appVersion: 1.2.3
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      icon: ""
+      apiVersion: v2
+    - name: alpine
+      url: https://charts.helm.sh/stable/alpine-0.2.0.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      created: "2018-07-09T11:34:37.797864902Z"
+      home: https://helm.sh/helm
+      sources:
+        - https://github.com/helm/helm
+      version: 0.2.0
+      appVersion: 2.3.4
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      icon: ""
+      apiVersion: v2
+    - name: alpine
+      url: https://charts.helm.sh/stable/alpine-0.3.0-rc.1.tgz
+      checksum: 0e6661f193211d7a5206918d42f5c2a9470b737d
+      created: "2020-11-12T08:44:58.872726222Z"
+      home: https://helm.sh/helm
+      sources:
+        - https://github.com/helm/helm
+      version: 0.3.0-rc.1
+      appVersion: 3.0.0
+      description: Deploy a basic Alpine Linux pod
+      keywords: []
+      maintainers: []
+      icon: ""
+      apiVersion: v2
+  mariadb:
+    - name: mariadb
+      url: https://charts.helm.sh/stable/mariadb-0.3.0.tgz
+      checksum: 65229f6de44a2be9f215d11dbff311673fc8ba56
+      created: "2018-04-23T08:20:27.160959131Z"
+      home: https://mariadb.org
+      sources:
+        - https://github.com/bitnami/bitnami-docker-mariadb
+      version: 0.3.0
+      description: Chart for MariaDB
+      keywords:
+        - mariadb
+        - mysql
+        - database
+        - sql
+      maintainers:
+        - name: Bitnami
+          email: containers@bitnami.com
+      icon: ""
+      apiVersion: v2

--- a/cmd/hypper/testdata/output/search-constraint-single.txt
+++ b/cmd/hypper/testdata/output/search-constraint-single.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.2.0        	2.3.4      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-constraint.txt
+++ b/cmd/hypper/testdata/output/search-constraint.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.1.0        	1.2.3      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-multiple-devel-release.txt
+++ b/cmd/hypper/testdata/output/search-multiple-devel-release.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.3.0-rc.1   	3.0.0      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-multiple-stable-release.txt
+++ b/cmd/hypper/testdata/output/search-multiple-stable-release.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.2.0        	2.3.4      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-multiple-versions-constraints.txt
+++ b/cmd/hypper/testdata/output/search-multiple-versions-constraints.txt
@@ -1,0 +1,3 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.2.0        	2.3.4      	Deploy a basic Alpine Linux pod
+testing/alpine	0.1.0        	1.2.3      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-multiple-versions.txt
+++ b/cmd/hypper/testdata/output/search-multiple-versions.txt
@@ -1,0 +1,3 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.2.0        	2.3.4      	Deploy a basic Alpine Linux pod
+testing/alpine	0.1.0        	1.2.3      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-not-found.txt
+++ b/cmd/hypper/testdata/output/search-not-found.txt
@@ -1,0 +1,1 @@
+No results found

--- a/cmd/hypper/testdata/output/search-output-json.txt
+++ b/cmd/hypper/testdata/output/search-output-json.txt
@@ -1,0 +1,1 @@
+[{"name":"testing/mariadb","version":"0.3.0","app_version":"","description":"Chart for MariaDB"}]

--- a/cmd/hypper/testdata/output/search-output-yaml.txt
+++ b/cmd/hypper/testdata/output/search-output-yaml.txt
@@ -1,0 +1,4 @@
+- app_version: 2.3.4
+  description: Deploy a basic Alpine Linux pod
+  name: testing/alpine
+  version: 0.2.0

--- a/cmd/hypper/testdata/output/search-regex.txt
+++ b/cmd/hypper/testdata/output/search-regex.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.2.0        	2.3.4      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/testdata/output/search-versions-constraint.txt
+++ b/cmd/hypper/testdata/output/search-versions-constraint.txt
@@ -1,0 +1,2 @@
+NAME          	CHART VERSION	APP VERSION	DESCRIPTION                    
+testing/alpine	0.1.0        	1.2.3      	Deploy a basic Alpine Linux pod

--- a/cmd/hypper/upgrade_test.go
+++ b/cmd/hypper/upgrade_test.go
@@ -396,8 +396,8 @@ func prepareMockRelease(releaseName string, t *testing.T) (func(n string, v int,
 }
 
 func TestUpgradeVersionCompletion(t *testing.T) {
-	repoFile := "testdata/helmhome/helm/repositories.yaml"
-	repoCache := "testdata/helmhome/helm/repository"
+	repoFile := "testdata/hypperhome/hypper/repositories.yaml"
+	repoCache := "testdata/hypperhome/hypper/repository"
 
 	repoSetup := fmt.Sprintf("--repository-config %s --repository-cache %s", repoFile, repoCache)
 

--- a/docs/user/howto/search.md
+++ b/docs/user/howto/search.md
@@ -1,0 +1,50 @@
+## Searching for charts in repos
+
+Search reads through all the repositories configured on the system, and looks for matches. Searching on these repositories uses the metadata stored on the system.
+
+It will display the latest stable versions of the charts found.
+
+```shell
+$ hypper search repo fleet
+NAME              	CHART VERSION	APP VERSION	DESCRIPTION                            
+hypper/fleet      	0.3.500      	0.3.5      	Fleet Manager - GitOps at Scale        
+hypper/fleet-agent	0.3.500      	0.3.5      	Fleet Manager Agent - GitOps at Scale  
+hypper/fleet-crd  	0.3.500      	0.3.5      	Fleet Manager CustomResourceDefinitions
+```
+
+By default, it will only show the latest version that match the keyword used. In order to see all versions you can use the `-l` flag.
+
+```shell
+$ hypper search repo fleet-agent -l
+NAME              	CHART VERSION	APP VERSION	DESCRIPTION                          
+hypper/fleet-agent	0.3.500      	0.3.5      	Fleet Manager Agent - GitOps at Scale
+hypper/fleet-agent	0.1.500      	0.1.5      	Fleet Manager Agent - GitOps at Scale
+```
+
+You can also search for a specific chart version by using the `--version VERSION` flag..
+
+Note that VERSION needs to be a valid SemVer version.
+
+```shell
+$ hypper search repo fleet-agent --version 0.1.500
+NAME              	CHART VERSION	APP VERSION	DESCRIPTION                          
+hypper/fleet-agent	0.1.500      	0.1.5      	Fleet Manager Agent - GitOps at Scale
+```
+
+It's also possible to pass the `--regexp` flag to use regexp in the search.
+
+```shell
+$ hypper search repo "fleet-" --regexp
+NAME              	CHART VERSION	APP VERSION	DESCRIPTION                            
+hypper/fleet-agent	0.3.500      	0.3.5      	Fleet Manager Agent - GitOps at Scale  
+hypper/fleet-crd  	0.3.500      	0.3.5      	Fleet Manager CustomResourceDefinitions
+```
+
+If you want to search for development charts (only stable charts are shown by default), use the `--devel` flag to show those development charts.
+
+
+```shell
+$ hypper search repo fleet-agent --devel
+NAME              	CHART VERSION	APP VERSION	DESCRIPTION                            
+hypper/fleet-agent	0.3.500-rc2      	0.3.5-rc2      	Fleet Manager Agent - GitOps at Scale
+```

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ replace (
 
 require (
 	github.com/Masterminds/log-go v0.4.0
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/fatih/color v1.10.0
 	github.com/gofrs/flock v0.8.0
 	github.com/gosuri/uitable v0.0.4

--- a/pkg/search/index.go
+++ b/pkg/search/index.go
@@ -1,0 +1,228 @@
+/*
+Copyright The Helm Authors, Suse LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*Package search provides client-side repository searching.
+
+This supports building an in-memory search index based on the contents of
+multiple repositories, and then using string matching or regular expressions
+to find matches.
+*/
+package search
+
+import (
+	"github.com/rancher-sandbox/hypper/pkg/repo"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+
+	helmRepo "helm.sh/helm/v3/pkg/repo"
+)
+
+// Result is a search result.
+//
+// Score indicates how close it is to match. The higher the score, the longer
+// the distance.
+type Result struct {
+	Name  string
+	Score int
+	Chart *helmRepo.ChartVersion
+}
+
+// Index is a searchable index of chart information.
+type Index struct {
+	lines  map[string]string
+	charts map[string]*helmRepo.ChartVersion
+}
+
+const sep = "\v"
+
+// NewIndex creates a new Index.
+func NewIndex() *Index {
+	return &Index{lines: map[string]string{}, charts: map[string]*helmRepo.ChartVersion{}}
+}
+
+// verSep is a separator for version fields in map keys.
+const verSep = "$$"
+
+// AddRepo adds a repository index to the search index.
+func (i *Index) AddRepo(rname string, ind *repo.IndexFile, all bool) {
+	ind.SortEntries()
+	for name, ref := range ind.Entries {
+		if len(ref) == 0 {
+			// Skip chart names that have zero releases.
+			continue
+		}
+		// By convention, an index file is supposed to have the newest at the
+		// 0 slot, so our best bet is to grab the 0 entry and build the index
+		// entry off of that.
+		// Note: Do not use filePath.Join since on Windows it will return \
+		//       which results in a repo name that cannot be understood.
+		fname := path.Join(rname, name)
+		if !all {
+			i.lines[fname] = indstr(rname, ref[0])
+			i.charts[fname] = ref[0]
+			continue
+		}
+
+		// If 'all' is set, then we go through all of the refs, and add them all
+		// to the index. This will generate a lot of near-duplicate entries.
+		for _, rr := range ref {
+			versionedName := fname + verSep + rr.Version
+			i.lines[versionedName] = indstr(rname, rr)
+			i.charts[versionedName] = rr
+		}
+	}
+}
+
+// All returns all charts in the index as if they were search results.
+//
+// Each will be given a score of 0.
+func (i *Index) All() []*Result {
+	res := make([]*Result, len(i.charts))
+	j := 0
+	for name, ch := range i.charts {
+		parts := strings.Split(name, verSep)
+		res[j] = &Result{
+			Name:  parts[0],
+			Chart: ch,
+		}
+		j++
+	}
+	return res
+}
+
+// Search searches an index for the given term.
+//
+// Threshold indicates the maximum score a term may have before being marked
+// irrelevant. (Low score means higher relevance. Golf, not bowling.)
+//
+// If regexp is true, the term is treated as a regular expression. Otherwise,
+// term is treated as a literal string.
+func (i *Index) Search(term string, threshold int, regexp bool) ([]*Result, error) {
+	if regexp {
+		return i.SearchRegexp(term, threshold)
+	}
+	return i.SearchLiteral(term, threshold), nil
+}
+
+// calcScore calculates a score for a match.
+func (i *Index) calcScore(index int, matchline string) int {
+
+	// This is currently tied to the fact that sep is a single char.
+	splits := []int{}
+	s := rune(sep[0])
+	for i, ch := range matchline {
+		if ch == s {
+			splits = append(splits, i)
+		}
+	}
+
+	for i, pos := range splits {
+		if index > pos {
+			continue
+		}
+		return i
+	}
+	return len(splits)
+}
+
+// SearchLiteral does a literal string search (no regexp).
+func (i *Index) SearchLiteral(term string, threshold int) []*Result {
+	term = strings.ToLower(term)
+	buf := []*Result{}
+	for k, v := range i.lines {
+		lk := strings.ToLower(k)
+		lv := strings.ToLower(v)
+		res := strings.Index(lv, term)
+		if score := i.calcScore(res, lv); res != -1 && score < threshold {
+			parts := strings.Split(lk, verSep) // Remove version, if it is there.
+			buf = append(buf, &Result{Name: parts[0], Score: score, Chart: i.charts[k]})
+		}
+	}
+	return buf
+}
+
+// SearchRegexp searches using a regular expression.
+func (i *Index) SearchRegexp(re string, threshold int) ([]*Result, error) {
+	matcher, err := regexp.Compile(re)
+	if err != nil {
+		return []*Result{}, err
+	}
+	buf := []*Result{}
+	for k, v := range i.lines {
+		ind := matcher.FindStringIndex(v)
+		if len(ind) == 0 {
+			continue
+		}
+		if score := i.calcScore(ind[0], v); ind[0] >= 0 && score < threshold {
+			parts := strings.Split(k, verSep) // Remove version, if it is there.
+			buf = append(buf, &Result{Name: parts[0], Score: score, Chart: i.charts[k]})
+		}
+	}
+	return buf, nil
+}
+
+// SortScore does an in-place sort of the results.
+//
+// Lowest scores are highest on the list. Matching scores are subsorted alphabetically.
+func SortScore(r []*Result) {
+	sort.Sort(scoreSorter(r))
+}
+
+// scoreSorter sorts results by score, and subsorts by alpha Name.
+type scoreSorter []*Result
+
+// Len returns the length of this scoreSorter.
+func (s scoreSorter) Len() int { return len(s) }
+
+// Swap performs an in-place swap.
+func (s scoreSorter) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+// Less compares a to b, and returns true if a is less than b.
+func (s scoreSorter) Less(a, b int) bool {
+	first := s[a]
+	second := s[b]
+
+	if first.Score > second.Score {
+		return false
+	}
+	if first.Score < second.Score {
+		return true
+	}
+	if first.Name == second.Name {
+		v1, err := semver.NewVersion(first.Chart.Version)
+		if err != nil {
+			return true
+		}
+		v2, err := semver.NewVersion(second.Chart.Version)
+		if err != nil {
+			return true
+		}
+		// Sort so that the newest chart is higher than the oldest chart. This is
+		// the opposite of what you'd expect in a function called Less.
+		return v1.GreaterThan(v2)
+	}
+	return first.Name < second.Name
+}
+
+func indstr(name string, ref *helmRepo.ChartVersion) string {
+	i := ref.Name + sep + name + "/" + ref.Name + sep +
+		ref.Description + sep + strings.Join(ref.Keywords, " ")
+	return i
+}

--- a/pkg/search/index_test.go
+++ b/pkg/search/index_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright The Helm Authors, Suse LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rancher-sandbox/hypper/pkg/repo"
+	"helm.sh/helm/v3/pkg/chart"
+	helmRepo "helm.sh/helm/v3/pkg/repo"
+)
+
+func TestSortScore(t *testing.T) {
+	in := []*Result{
+		{Name: "bbb", Score: 0, Chart: &helmRepo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.3"}}},
+		{Name: "aaa", Score: 5},
+		{Name: "abb", Score: 5},
+		{Name: "aab", Score: 0},
+		{Name: "bab", Score: 5},
+		{Name: "ver", Score: 5, Chart: &helmRepo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.4"}}},
+		{Name: "ver", Score: 5, Chart: &helmRepo.ChartVersion{Metadata: &chart.Metadata{Version: "1.2.3"}}},
+	}
+	expect := []string{"aab", "bbb", "aaa", "abb", "bab", "ver", "ver"}
+	expectScore := []int{0, 0, 5, 5, 5, 5, 5}
+	SortScore(in)
+
+	// Test Score
+	for i := 0; i < len(expectScore); i++ {
+		if expectScore[i] != in[i].Score {
+			t.Errorf("Sort error on index %d: expected %d, got %d", i, expectScore[i], in[i].Score)
+		}
+	}
+	// Test Name
+	for i := 0; i < len(expect); i++ {
+		if expect[i] != in[i].Name {
+			t.Errorf("Sort error: expected %s, got %s", expect[i], in[i].Name)
+		}
+	}
+
+	// Test version of last two items
+	if in[5].Chart.Version != "1.2.4" {
+		t.Errorf("Expected 1.2.4, got %s", in[5].Chart.Version)
+	}
+	if in[6].Chart.Version != "1.2.3" {
+		t.Error("Expected 1.2.3 to be last")
+	}
+}
+
+var indexfileEntries = map[string]helmRepo.ChartVersions{
+	"niña": {
+		{
+			URLs: []string{"http://example.com/charts/nina-0.1.0.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "niña",
+				Version:     "0.1.0",
+				Description: "One boat",
+			},
+		},
+	},
+	"pinta": {
+		{
+			URLs: []string{"http://example.com/charts/pinta-0.1.0.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "pinta",
+				Version:     "0.1.0",
+				Description: "Two ship",
+			},
+		},
+	},
+	"santa-maria": {
+		{
+			URLs: []string{"http://example.com/charts/santa-maria-1.2.3.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "santa-maria",
+				Version:     "1.2.3",
+				Description: "Three boat",
+			},
+		},
+		{
+			URLs: []string{"http://example.com/charts/santa-maria-1.2.2-rc-1.tgz"},
+			Metadata: &chart.Metadata{
+				Name:        "santa-maria",
+				Version:     "1.2.2-RC-1",
+				Description: "Three boat",
+			},
+		},
+	},
+}
+
+func loadTestIndex(t *testing.T, all bool) *Index {
+	i := NewIndex()
+	i.AddRepo("testing", &repo.IndexFile{IndexFile: &helmRepo.IndexFile{Entries: indexfileEntries}}, all)
+	i.AddRepo("ztesting", &repo.IndexFile{IndexFile: &helmRepo.IndexFile{Entries: map[string]helmRepo.ChartVersions{
+		"pinta": {
+			{
+				URLs: []string{"http://example.com/charts/pinta-2.0.0.tgz"},
+				Metadata: &chart.Metadata{
+					Name:        "pinta",
+					Version:     "2.0.0",
+					Description: "Two ship, version two",
+				},
+			},
+		},
+	}}}, all)
+	return i
+}
+
+func TestAll(t *testing.T) {
+	i := loadTestIndex(t, false)
+	all := i.All()
+	if len(all) != 4 {
+		t.Errorf("Expected 4 entries, got %d", len(all))
+	}
+
+	i = loadTestIndex(t, true)
+	all = i.All()
+	if len(all) != 5 {
+		t.Errorf("Expected 5 entries, got %d", len(all))
+	}
+}
+
+func TestAddRepo_Sort(t *testing.T) {
+	i := loadTestIndex(t, true)
+	sr, err := i.Search("TESTING/SANTA-MARIA", 100, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	SortScore(sr)
+
+	ch := sr[0]
+	expect := "1.2.3"
+	if ch.Chart.Version != expect {
+		t.Errorf("Expected %q, got %q", expect, ch.Chart.Version)
+	}
+}
+
+func TestSearchByName(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		query   string
+		expect  []*Result
+		regexp  bool
+		fail    bool
+		failMsg string
+	}{
+		{
+			name:  "basic search for one result",
+			query: "santa-maria",
+			expect: []*Result{
+				{Name: "testing/santa-maria"},
+			},
+		},
+		{
+			name:  "basic search for two results",
+			query: "pinta",
+			expect: []*Result{
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
+			},
+		},
+		{
+			name:  "repo-specific search for one result",
+			query: "ztesting/pinta",
+			expect: []*Result{
+				{Name: "ztesting/pinta"},
+			},
+		},
+		{
+			name:  "partial name search",
+			query: "santa",
+			expect: []*Result{
+				{Name: "testing/santa-maria"},
+			},
+		},
+		{
+			name:  "description search, one result",
+			query: "Three",
+			expect: []*Result{
+				{Name: "testing/santa-maria"},
+			},
+		},
+		{
+			name:  "description search, two results",
+			query: "two",
+			expect: []*Result{
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
+			},
+		},
+		{
+			name:  "description upper search, two results",
+			query: "TWO",
+			expect: []*Result{
+				{Name: "testing/pinta"},
+				{Name: "ztesting/pinta"},
+			},
+		},
+		{
+			name:   "nothing found",
+			query:  "mayflower",
+			expect: []*Result{},
+		},
+		{
+			name:  "regexp, one result",
+			query: "Th[ref]*",
+			expect: []*Result{
+				{Name: "testing/santa-maria"},
+			},
+			regexp: true,
+		},
+		{
+			name:    "regexp, fail compile",
+			query:   "th[",
+			expect:  []*Result{},
+			regexp:  true,
+			fail:    true,
+			failMsg: "error parsing regexp:",
+		},
+	}
+
+	i := loadTestIndex(t, false)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			charts, err := i.Search(tt.query, 100, tt.regexp)
+			if err != nil {
+				if tt.fail {
+					if !strings.Contains(err.Error(), tt.failMsg) {
+						t.Fatalf("Unexpected error message: %s", err)
+					}
+					return
+				}
+				t.Fatalf("%s: %s", tt.name, err)
+			}
+			// Give us predictably ordered results.
+			SortScore(charts)
+
+			l := len(charts)
+			if l != len(tt.expect) {
+				t.Fatalf("Expected %d result, got %d", len(tt.expect), l)
+			}
+			// For empty result sets, just keep going.
+			if l == 0 {
+				return
+			}
+
+			for i, got := range charts {
+				ex := tt.expect[i]
+				if got.Name != ex.Name {
+					t.Errorf("[%d]: Expected name %q, got %q", i, ex.Name, got.Name)
+				}
+			}
+
+		})
+	}
+}
+
+func TestSearchByNameAll(t *testing.T) {
+	// Test with the All bit turned on.
+	i := loadTestIndex(t, true)
+	cs, err := i.Search("santa-maria", 100, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cs) != 2 {
+		t.Errorf("expected 2 charts, got %d", len(cs))
+	}
+}
+
+func TestCalcScore(t *testing.T) {
+	i := NewIndex()
+
+	fields := []string{"aaa", "bbb", "ccc", "ddd"}
+	matchline := strings.Join(fields, sep)
+	if r := i.calcScore(2, matchline); r != 0 {
+		t.Errorf("Expected 0, got %d", r)
+	}
+	if r := i.calcScore(5, matchline); r != 1 {
+		t.Errorf("Expected 1, got %d", r)
+	}
+	if r := i.calcScore(10, matchline); r != 2 {
+		t.Errorf("Expected 2, got %d", r)
+	}
+	if r := i.calcScore(14, matchline); r != 3 {
+		t.Errorf("Expected 3, got %d", r)
+	}
+}

--- a/pkg/search/search.go
+++ b/pkg/search/search.go
@@ -1,0 +1,224 @@
+/*
+Copyright The Helm Authors, Suse LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* Package search implements the search for charts in repos but extracts it into a package
+so it can be reused and composed over
+Currently the helm search is implemented under the cmd dir which means that most
+of its options cant be used in a composite struct to build on top of them
+*/
+package search
+
+import (
+	"fmt"
+	"github.com/Masterminds/log-go"
+	logio "github.com/Masterminds/log-go/io"
+	"github.com/Masterminds/semver/v3"
+	"github.com/gosuri/uitable"
+	"github.com/pkg/errors"
+	"github.com/rancher-sandbox/hypper/pkg/hypperpath"
+	"github.com/rancher-sandbox/hypper/pkg/repo"
+	"helm.sh/helm/v3/pkg/cli/output"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// searchMaxScore suggests that any score higher than this is not considered a match.
+const searchMaxScore = 25
+
+func isNotExist(err error) bool {
+	return os.IsNotExist(errors.Cause(err))
+}
+
+// RepoOptions is the struct used to search, and stores the different options to filter and configure the output
+type RepoOptions struct {
+	Versions     bool
+	Regexp       bool
+	Devel        bool
+	Version      string
+	MaxColWidth  uint
+	RepoFile     string
+	RepoCacheDir string
+	OutputFormat output.Format
+}
+
+// Run searchs and prints the found charts based of the filters
+func (o *RepoOptions) Run(logger log.Logger, args []string) error {
+	wInfo := logio.NewWriter(logger, log.InfoLevel)
+	o.setupSearchedVersion()
+
+	index, err := o.buildIndex()
+	if err != nil {
+		return err
+	}
+
+	var res []*Result
+	if len(args) == 0 {
+		res = index.All()
+	} else {
+		q := strings.Join(args, " ")
+		res, err = index.Search(q, searchMaxScore, o.Regexp)
+		if err != nil {
+			return err
+		}
+	}
+
+	SortScore(res)
+	data, err := o.applyConstraint(res)
+	if err != nil {
+		return err
+	}
+
+	return o.OutputFormat.Write(wInfo, &repoSearchWriter{data, o.MaxColWidth})
+}
+
+// setupSearchedVersion sets the version to search the chart
+// if no version is set it sets it to any semver version higher than 0.0.0
+func (o *RepoOptions) setupSearchedVersion() {
+	log.Debug("Original chart version: %q", o.Version)
+
+	if o.Version != "" {
+		return
+	}
+
+	if o.Devel { // search for releases and prereleases (alpha, beta, and release candidate releases).
+		log.Debug("setting version to >0.0.0-0")
+		o.Version = ">0.0.0-0"
+	} else { // search only for stable releases, prerelease versions will be skip
+		log.Debug("setting version to >0.0.0")
+		o.Version = ">0.0.0"
+	}
+}
+
+// applyConstraint get a result list and filters it based on the version constraint set
+func (o *RepoOptions) applyConstraint(res []*Result) ([]*Result, error) {
+	if o.Version == "" {
+		return res, nil
+	}
+
+	constraint, err := semver.NewConstraint(o.Version)
+	if err != nil {
+		return res, errors.Wrap(err, "an invalid version/constraint format")
+	}
+
+	data := res[:0]
+	foundNames := map[string]bool{}
+	for _, r := range res {
+		// if not returning all versions and already have found a result,
+		// you're done!
+		if !o.Versions && foundNames[r.Name] {
+			continue
+		}
+		v, err := semver.NewVersion(r.Chart.Version)
+		if err != nil {
+			continue
+		}
+		if constraint.Check(v) {
+			data = append(data, r)
+			foundNames[r.Name] = true
+		}
+	}
+
+	return data, nil
+}
+
+// buildIndex loads the repos to add them to the index search
+func (o *RepoOptions) buildIndex() (*Index, error) {
+	// Load the repositories.yaml
+	rf, err := repo.LoadFile(o.RepoFile)
+	if isNotExist(err) || len(rf.Repositories) == 0 {
+		return nil, errors.New("no repositories configured")
+	}
+
+	i := NewIndex()
+	for _, re := range rf.Repositories {
+		n := re.Name
+		f := filepath.Join(o.RepoCacheDir, hypperpath.CacheIndexFile(n))
+		ind, err := repo.LoadIndexFile(f)
+		if err != nil {
+			log.Warn("Repo %q is corrupt or missing. Try 'hypper repo update'.", n)
+			log.Warn("%s", err)
+			continue
+		}
+
+		i.AddRepo(n, ind, o.Versions || len(o.Version) > 0)
+	}
+	return i, nil
+}
+
+// repoChartElement is used to store the final chart values that will get printed
+type repoChartElement struct {
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	AppVersion  string `json:"app_version"`
+	Description string `json:"description"`
+}
+
+// repoSearchWriter is used to store and print the search results
+type repoSearchWriter struct {
+	results     []*Result
+	columnWidth uint
+}
+
+// WriteTable writes the results as a table
+func (r *repoSearchWriter) WriteTable(out io.Writer) error {
+	if len(r.results) == 0 {
+		_, err := out.Write([]byte("No results found\n"))
+		if err != nil {
+			return fmt.Errorf("unable to write results: %s", err)
+		}
+		return nil
+	}
+	table := uitable.New()
+	table.MaxColWidth = r.columnWidth
+	table.AddRow("NAME", "CHART VERSION", "APP VERSION", "DESCRIPTION")
+	for _, r := range r.results {
+		table.AddRow(r.Name, r.Chart.Version, r.Chart.AppVersion, r.Chart.Description)
+	}
+	return output.EncodeTable(out, table)
+}
+
+// WriteJSON prints the results as a json
+func (r *repoSearchWriter) WriteJSON(out io.Writer) error {
+	return r.encodeByFormat(out, output.JSON)
+}
+
+// WriteYAML prints the results as a yaml
+func (r *repoSearchWriter) WriteYAML(out io.Writer) error {
+	return r.encodeByFormat(out, output.YAML)
+}
+
+// encodeByFormat creates the final Chartlist that will get formatted into the final results
+func (r *repoSearchWriter) encodeByFormat(out io.Writer, format output.Format) error {
+	// Initialize the array so no results returns an empty array instead of null
+	chartList := make([]repoChartElement, 0, len(r.results))
+
+	for _, r := range r.results {
+		chartList = append(chartList, repoChartElement{r.Name, r.Chart.Version, r.Chart.AppVersion, r.Chart.Description})
+	}
+
+	switch format {
+	case output.JSON:
+		return output.EncodeJSON(out, chartList)
+	case output.YAML:
+		return output.EncodeYAML(out, chartList)
+	}
+
+	// Because this is a non-exported function and only called internally by
+	// WriteJSON and WriteYAML, we shouldn't get invalid types
+	return nil
+}


### PR DESCRIPTION
Adds the helm repo search command to hypper as just hypper search

Under helm you can search on the repos or on their own hub. This
patch only implements the repo search as seems the most useful
and bringing the hub requires a lot of code

This patch also extracts the search code into a new pkg as under
helm the search code is mostly crammed under cmd which means you cannot
use it anywhere, meanwhile this code can be reused by third party
clients to implement their own search frontend or automate it.

Fixes: #78 

Signed-off-by: Itxaka <igarcia@suse.com>