### PR TITLE
Add filtering by annotations on search

### DIFF
--- a/cmd/hypper/search.go
+++ b/cmd/hypper/search.go
@@ -85,6 +85,7 @@ func newSearchRepoCmd(logger log.Logger) *cobra.Command {
 	f.BoolVarP(&o.Versions, "versions", "l", false, "show the long listing, with each version of each chart on its own line, for repositories you have added")
 	f.BoolVar(&o.Devel, "devel", false, "use development versions (alpha, beta, and release candidate releases), too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.StringVar(&o.Version, "version", "", "search using semantic versioning constraints on repositories you have added")
+	f.StringToStringVarP(&o.Annotations, "annotations", "a", map[string]string{}, "filter using annotations. The format is --annotations key=value")
 	f.UintVar(&o.MaxColWidth, "max-col-width", 50, "maximum column width for output table")
 	bindOutputFlag(cmd, &o.OutputFormat)
 

--- a/cmd/hypper/search_test.go
+++ b/cmd/hypper/search_test.go
@@ -72,7 +72,32 @@ func TestSearchRepositoriesCmd(t *testing.T) {
 		name:   "search for 'alpine', expect valid yaml output",
 		cmd:    "search repo alpine --output yaml",
 		golden: "output/search-output-yaml.txt",
-	}}
+	}, {
+		name:   "search for hypper, expect latest version 0.2.0",
+		cmd:    "search repo hypper --output yaml",
+		golden: "output/search-hypper-latest.txt",
+	}, { // I use yaml for the output because its easier to create the golden files, sue me :p
+		// Should find version 0.1.0 as that is the only one with that annotation
+		name:   "search for hypper with annotation hypper.cattle.io/namespace:hyppernamespace",
+		cmd:    "search repo hypper -a 'hypper.cattle.io/namespace=hyppernamespace' --output yaml",
+		golden: "output/search-hypper-annotation.txt",
+	}, {
+		// Should find latest version 0.2.0 with that annotation
+		name:   "search for hypper with regexp annotation hypper.cattle.io/release-name:hypper*",
+		cmd:    "search repo hypper --regexp -a 'hypper.cattle.io/release-name=hypper*' --output yaml",
+		golden: "output/search-hypper-annotation-regexp.txt",
+	}, {
+		// Should find that exact version with the annotation, not the latest
+		name:   "search for hypper with version and annotation hypper.cattle.io/release-name:hyppername",
+		cmd:    "search repo hypper --version 0.1.0 -a 'hypper.cattle.io/release-name=hyppername' --output yaml",
+		golden: "output/search-hypper-annotation-version.txt",
+	}, {
+		// Now everything at the same time! regexp! version! annotations!
+		name:   "search for hypper with version and annotation hypper.cattle.io/release-name:hyppername",
+		cmd:    "search repo hypper --regexp --version 0.1.0 -a 'hypper.cattle.io/release-name=^hypper' --output yaml",
+		golden: "output/search-hypper-annotation-version-regexp.txt",
+	},
+	}
 
 	settings.Debug = true
 	defer func() { settings.Debug = false }()

--- a/cmd/hypper/testdata/hypperhome/hypper/repository/testing-index.yaml
+++ b/cmd/hypper/testdata/hypperhome/hypper/repository/testing-index.yaml
@@ -64,3 +64,23 @@ entries:
           email: containers@bitnami.com
       icon: ""
       apiVersion: v2
+  hypper:
+    - name: hypper
+      url: https://example.com/stable/hypper-0.1.0.tgz
+      created: "2018-04-23T08:20:27.160959131Z"
+      version: 0.1.0
+      description: Chart for hypper
+      icon: ""
+      apiVersion: v2
+      annotations:
+        hypper.cattle.io/namespace: hyppernamespace
+        hypper.cattle.io/release-name: hyppername
+    - name: hypper
+      url: https://example.com/stable/hypper-0.2.0.tgz
+      created: "2018-04-23T08:20:27.160959131Z"
+      version: 0.2.0
+      description: Chart for hypper
+      icon: ""
+      apiVersion: v2
+      annotations:
+        hypper.cattle.io/release-name: hyppername

--- a/cmd/hypper/testdata/output/search-hypper-annotation-regexp.txt
+++ b/cmd/hypper/testdata/output/search-hypper-annotation-regexp.txt
@@ -1,0 +1,4 @@
+- app_version: ""
+  description: Chart for hypper
+  name: testing/hypper
+  version: 0.2.0

--- a/cmd/hypper/testdata/output/search-hypper-annotation-version-regexp.txt
+++ b/cmd/hypper/testdata/output/search-hypper-annotation-version-regexp.txt
@@ -1,0 +1,4 @@
+- app_version: ""
+  description: Chart for hypper
+  name: testing/hypper
+  version: 0.1.0

--- a/cmd/hypper/testdata/output/search-hypper-annotation-version.txt
+++ b/cmd/hypper/testdata/output/search-hypper-annotation-version.txt
@@ -1,0 +1,4 @@
+- app_version: ""
+  description: Chart for hypper
+  name: testing/hypper
+  version: 0.1.0

--- a/cmd/hypper/testdata/output/search-hypper-annotation.txt
+++ b/cmd/hypper/testdata/output/search-hypper-annotation.txt
@@ -1,0 +1,4 @@
+- app_version: ""
+  description: Chart for hypper
+  name: testing/hypper
+  version: 0.1.0

--- a/cmd/hypper/testdata/output/search-hypper-latest.txt
+++ b/cmd/hypper/testdata/output/search-hypper-latest.txt
@@ -1,0 +1,4 @@
+- app_version: ""
+  description: Chart for hypper
+  name: testing/hypper
+  version: 0.2.0

--- a/docs/user/howto/searchannotations.md
+++ b/docs/user/howto/searchannotations.md
@@ -1,0 +1,34 @@
+## Searching for charts in repos using annotations
+
+Apart from having the normal [search](docs/user/howto/search.md) in hypper, we support searching for specific annotations in a search.
+
+Using the `-a` flag in `hypper search repo` allows to filter the returned charts based on the KEY=VALUE values in annotations.
+
+```shell
+$ hypper search repo -a 'hypper.cattle.io/release-name=fleet'       
+NAME        	CHART VERSION	APP VERSION	DESCRIPTION                    
+hypper/fleet	0.3.500      	0.3.5      	Fleet Manager - GitOps at Scale
+
+```
+
+
+We also support the `--regexp` flag when using annotations, so you can search for the VALUE with a regexp
+
+```shell
+$ hypper search repo -a 'hypper.cattle.io/release-name=.*crd.*' --regexp
+NAME                            	CHART VERSION	APP VERSION	DESCRIPTION                                 
+hypper/fleet-crd                	0.3.500      	0.3.5      	Fleet Manager CustomResourceDefinitions     
+hypper/longhorn-crd             	1.1.001      	           	Installs the CRDs for longhorn.             
+hypper/rancher-backup-crd       	1.0.400      	1.0.4      	Installs the CRDs for rancher-backup.       
+hypper/rancher-cis-benchmark-crd	1.0.301      	           	Installs the CRDs for rancher-cis-benchmark.
+hypper/rancher-gatekeeper-crd   	3.3.001      	           	Installs the CRDs for rancher-gatekeeper.   
+hypper/rancher-logging-crd      	3.9.002      	           	Installs the CRDs for rancher-logging.      
+hypper/rancher-monitoring-crd   	9.4.204      	           	Installs the CRDs for rancher-monitoring.   
+hypper/rancher-operator-crd     	0.1.300      	0.1.3      	Rancher Operator CustomResourceDefinitions  
+
+```
+
+Of course the usual search flags also work in conjunction with annotations, so you can search for annotations *and* a specific version with he `--version` flag for example. 
+
+
+Note: Currently you can pass more than one annotation to search for. This is currently an OR filter, so if any of the given annotation are found in a chart, it will match.

--- a/pkg/search/doc.go
+++ b/pkg/search/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright Suse LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package search
+/* Provides client-side repository searching
+
+Currently the helm search is implemented under the cmd dir which means that most
+of its options cant be used in a composite struct to build on top of them
+
+Our implementation but extracts it into a package so it can be reused and composed over
+
+
+Search supports building an in-memory search index based on the contents of
+multiple repositories, and then using string matching or regular expressions
+to find matches based on the name, version or annotations.
+*/
+package search

--- a/pkg/search/index.go
+++ b/pkg/search/index.go
@@ -14,12 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*Package search provides client-side repository searching.
-
-This supports building an in-memory search index based on the contents of
-multiple repositories, and then using string matching or regular expressions
-to find matches.
-*/
 package search
 
 import (


### PR DESCRIPTION
Allows to add filtering by annotations by passing the -a flag and the
annotation in the format "KEY=VALUE"
    
So you can search like this:

`hypper search repo -a "catalog.cattle.io/certified=rancher"`

And it will only show charts that have that exact annotation.

Requires #113 

Signed-off-by: Itxaka <igarcia@suse.com>