### PR TITLE
Fix helm settings for flags

### DIFF
--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -57,6 +57,9 @@ func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []st
 	flags.ParseErrorsWhitelist.UnknownFlags = true
 	err := flags.Parse(args)
 
+	// Flags are parsed, lets fill the helm cli.Settings with our current settings
+	settings.FillHelmSettings()
+
 	if err != nil && !errors.Is(err, pflag.ErrHelp) {
 		log.Errorf("failed while parsing flags for %s: %s", args, err)
 

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -106,7 +106,10 @@ func New() *EnvSettings {
 		NoColors: false,
 		NoEmojis: false,
 	}
-	os.Setenv("HELM_NAMESPACE", env.namespace)
+
+	os.Setenv("HELM_NAMESPACE", env.namespace) // WHY???
+
+	// Create default helm settings and propagate our default hypper values
 	env.EnvSettings = cli.New()
 
 	env.EnvSettings.MaxHistory = env.MaxHistory
@@ -139,6 +142,22 @@ func New() *EnvSettings {
 	}
 
 	return env
+}
+
+// FillHelmSettings will fill the helm cli.Settings with the proper values from CLI flags
+// This has to be called after the flags are set, otherwise the flags are not propagated to Helm cli.Settings
+func (s *EnvSettings) FillHelmSettings() {
+	s.EnvSettings.MaxHistory = s.MaxHistory
+	s.EnvSettings.KubeContext = s.KubeContext
+	s.EnvSettings.KubeToken = s.KubeToken
+	s.EnvSettings.KubeAsUser = s.KubeAsUser
+	s.EnvSettings.KubeAsGroups = s.KubeAsGroups
+	s.EnvSettings.KubeAPIServer = s.KubeAPIServer
+	s.EnvSettings.KubeCaFile = s.KubeCaFile
+	s.EnvSettings.PluginsDirectory = s.PluginsDirectory
+	s.EnvSettings.RegistryConfig = s.RegistryConfig
+	s.EnvSettings.RepositoryCache = s.RepositoryCache
+	s.EnvSettings.RepositoryConfig = s.RepositoryConfig
 }
 
 // AddFlags binds flags to the given flagset.

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -112,17 +112,7 @@ func New() *EnvSettings {
 	// Create default helm settings and propagate our default hypper values
 	env.EnvSettings = cli.New()
 
-	env.EnvSettings.MaxHistory = env.MaxHistory
-	env.EnvSettings.KubeContext = env.KubeContext
-	env.EnvSettings.KubeToken = env.KubeToken
-	env.EnvSettings.KubeAsUser = env.KubeAsUser
-	env.EnvSettings.KubeAsGroups = env.KubeAsGroups
-	env.EnvSettings.KubeAPIServer = env.KubeAPIServer
-	env.EnvSettings.KubeCaFile = env.KubeCaFile
-	env.EnvSettings.PluginsDirectory = env.PluginsDirectory
-	env.EnvSettings.RegistryConfig = env.RegistryConfig
-	env.EnvSettings.RepositoryCache = env.RepositoryCache
-	env.EnvSettings.RepositoryConfig = env.RepositoryConfig
+	env.FillHelmSettings()
 
 	env.Debug, _ = strconv.ParseBool(os.Getenv("HYPPER_DEBUG"))
 	env.Verbose, _ = strconv.ParseBool(os.Getenv("HYPPER_TRACE"))


### PR DESCRIPTION
We were filling all the helm settings before parsing the
flags, which means that anything using those helm settings for
any action would just get the default values instead of any cli
values.

This fixes the issue by creating a fill function and calling
it after the flags have been parsed, thus making sure that those
flags are properly propagated.

Otherwise the envsettings behavior its the same as it was before
as the default hypoper values are propagated to helm settings on
Envsettings construct

Signed-off-by: Itxaka <igarcia@suse.com>