### PR TITLE
Add docs generation to workflows

### DIFF
--- a/.github/workflows/docs-book.yml
+++ b/.github/workflows/docs-book.yml
@@ -1,0 +1,24 @@
+name: Documentation book
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.4.3'
+      - run: mdbook build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./book

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bin/
 
 # code coverage
 coverage.out
+
+book/
+

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,7 @@
+[book]
+title = "Hypper documentation"
+src = "docs"
+create-missing = false
+
+[output.html]
+git-repository-url = "https://github.com/rancher-sandbox/hypper"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+- [Hypper Design](./design.md)
+- [Installing](./user/tutorials/installing.md)
+- [Quick Start](./user/tutorials/quickstart.md)
+- [How tos](./user/howto/README.md)
+    - [Expand a chart with Hypper annotations](./user/howto/expandcharthypper.md)

--- a/docs/user/howto/README.md
+++ b/docs/user/howto/README.md
@@ -1,0 +1,1 @@
+This section contains some "How tos" that offer practical advice and detailed instruction in an activity. 

--- a/docs/user/tutorials/installing.md
+++ b/docs/user/tutorials/installing.md
@@ -72,6 +72,6 @@ We do not recommend using development snapshots on your production environment.*
 
 In most cases, installation is as simple as getting a pre-built hypper binary. This document covers additional cases for those who want to do more sophisticated things with Hypper.
 
-Once you have the Hypper Client successfully installed, you can move on to the [quickstart guide](docs/user/tutorials/quickstart.md).
+Once you have the Hypper Client successfully installed, you can move on to the [quickstart guide](https://github.com/rancher-sandbox/hypper/docs/user/tutorials/quickstart.md).
 
 [Github Actions]: https://github.com/rancher-sandbox/hypper/actions/workflows/ci.yml?query=branch%3Amain+is%3Asuccess+workflow%3ACI


### PR DESCRIPTION
This uses mdBook to generate a book with all the
docs based of the SUMMARY.md file and with the book.toml
configuration.

Then it builds the book with the docs unders docs in the book/
directory and pushes that to the gh-pages branch which then is
published by github pages, making the docs available

Signed-off-by: Itxaka <igarcia@suse.com>