### PR TITLE
feat: Add initial functionality to install shared deps of a chart

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -31,6 +31,7 @@ import (
 	"github.com/Masterminds/log-go"
 	logio "github.com/Masterminds/log-go/io"
 	"github.com/rancher-sandbox/hypper/pkg/action"
+	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 )
 
@@ -61,7 +62,7 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			// TODO decide how to use returned rel:
-			_, err := runInstall(args, client, valueOpts, logger)
+			_, err := runInstall(args, client, valueOpts, logger, settings)
 			if err != nil {
 				return err
 			}
@@ -82,7 +83,10 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.NoSharedDeps, "no-shared-deps", false, "skip installation of shared dependencies")
 }
 
-func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger) (*release.Release, error) {
+func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger, settings *cli.EnvSettings) (*release.Release, error) {
+
+	// TODO code for loading a chart maybe shouldn't be here, but in
+	// pkg/action/install.go???
 
 	// Get an io.Writer compliant logger instance at the info level.
 	wInfo := logio.NewWriter(logger, log.InfoLevel)
@@ -164,5 +168,5 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	return client.Run(chartRequested, vals)
+	return client.Run(chartRequested, vals, settings, logger)
 }

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -21,7 +21,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"helm.sh/helm/v3/cmd/helm/require"
-	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli/output"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -127,7 +126,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 		}
 	}
 
-	if err := checkIfInstallable(chartRequested); err != nil {
+	if err := action.CheckIfInstallable(chartRequested); err != nil {
 		return nil, err
 	}
 
@@ -165,15 +164,4 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	}
 
 	return client.Run(chartRequested, vals)
-}
-
-// checkIfInstallable validates if a chart can be installed
-//
-// Application chart type is only installable
-func checkIfInstallable(ch *chart.Chart) error {
-	switch ch.Metadata.Type {
-	case "", "application":
-		return nil
-	}
-	return errors.Errorf("%s charts are not installable", ch.Metadata.Type)
 }

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -87,6 +87,7 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	// Get an io.Writer compliant logger instance at the info level.
 	wInfo := logio.NewWriter(logger, log.InfoLevel)
 
+	logger.Debugf("Original chart version: %q", client.Version)
 	if client.Version == "" && client.Devel {
 		logger.Debug("setting version to >0.0.0-0")
 		client.Version = ">0.0.0-0"

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -79,6 +79,7 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 
 func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
 	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
+	f.BoolVar(&client.NoSharedDeps, "no-shared-deps", false, "skip installation of shared dependencies")
 }
 
 func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger) (*release.Release, error) {

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -31,7 +31,6 @@ import (
 	"github.com/Masterminds/log-go"
 	logio "github.com/Masterminds/log-go/io"
 	"github.com/rancher-sandbox/hypper/pkg/action"
-	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 )
 
@@ -62,7 +61,7 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 		Args:  require.MinimumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
 			// TODO decide how to use returned rel:
-			_, err := runInstall(args, client, valueOpts, logger, settings)
+			_, err := runInstall(args, client, valueOpts, logger)
 			if err != nil {
 				return err
 			}
@@ -83,7 +82,7 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.BoolVar(&client.NoSharedDeps, "no-shared-deps", false, "skip installation of shared dependencies")
 }
 
-func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger, settings *cli.EnvSettings) (*release.Release, error) {
+func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger) (*release.Release, error) {
 
 	// TODO code for loading a chart maybe shouldn't be here, but in
 	// pkg/action/install.go???

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -84,9 +84,6 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 
 func runInstall(args []string, client *action.Install, valueOpts *values.Options, logger log.Logger) (*release.Release, error) {
 
-	// TODO code for loading a chart maybe shouldn't be here, but in
-	// pkg/action/install.go???
-
 	// Get an io.Writer compliant logger instance at the info level.
 	wInfo := logio.NewWriter(logger, log.InfoLevel)
 

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -32,37 +32,37 @@ func TestInstallCmd(t *testing.T) {
 		// Install, name and namespace as args
 		{
 			name:   "install, name and ns as args",
-			cmd:    "install zeppelin testdata/testcharts/hypper-annot -n led",
+			cmd:    "install zeppelin testdata/testcharts/hypper-annot -n led --no-shared-deps",
 			golden: "output/install-name-ns-args.txt",
 		},
 		// Install, name and namespace as args, create ns
 		{
 			name:   "install, name and ns as args",
-			cmd:    "install purple testdata/testcharts/hypper-annot --namespace deep --create-namespace",
+			cmd:    "install purple testdata/testcharts/hypper-annot --namespace deep --create-namespace --no-shared-deps",
 			golden: "output/install-create-namespace.txt",
 		},
 		// Install, hypper annot have priority over fallback annot
 		{
 			name:   "install, hypper annot have priority over fallback annot",
-			cmd:    "install testdata/testcharts/hypper-annot",
+			cmd:    "install testdata/testcharts/hypper-annot --no-shared-deps",
 			golden: "output/install-hypper-annot.txt",
 		},
 		// Install, fallback annotations
 		{
 			name:   "install, fallback annotations",
-			cmd:    "install testdata/testcharts/fallback-annot",
+			cmd:    "install testdata/testcharts/fallback-annot --no-shared-deps",
 			golden: "output/install-fallback-annot.txt",
 		},
 		// Install, annotations have priority over default name from Chart.yml
 		{
 			name:   "install, annot have priority over default name from Chart.yml",
-			cmd:    "install testdata/testcharts/hypper-annot",
+			cmd:    "install testdata/testcharts/hypper-annot --no-shared-deps",
 			golden: "output/install-hypper-annot.txt",
 		},
 		// Install, no name or annotations specified
 		{
 			name:   "install, with no name or annot specified",
-			cmd:    "install testdata/testcharts/vanilla-helm",
+			cmd:    "install testdata/testcharts/vanilla-helm --no-shared-deps",
 			golden: "output/install-no-name-or-annot.txt",
 		},
 	}

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -65,6 +65,12 @@ func TestInstallCmd(t *testing.T) {
 			cmd:    "install testdata/testcharts/vanilla-helm --no-shared-deps",
 			golden: "output/install-no-name-or-annot.txt",
 		},
+		// Install, with shared deps
+		{
+			name:   "install, with shared deps",
+			cmd:    "install testdata/testcharts/shared-deps",
+			golden: "output/install-with-shared-deps.txt",
+		},
 	}
 	runTestActionCmd(t, tests)
 }

--- a/cmd/hypper/testdata/output/install-with-shared-deps.txt
+++ b/cmd/hypper/testdata/output/install-with-shared-deps.txt
@@ -1,0 +1,3 @@
+Installing chart "empty" in namespace "hypper"…
+Installing chart "my-hypper-name" in namespace "hypper"…
+Done! 👏 

--- a/cmd/hypper/testdata/testcharts/shared-deps/Chart.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://helm.sh/helm
+name: empty
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+annotations:
+  hypper.cattle.io/namespace: hypper
+  hypper.cattle.io/release-name: my-hypper-name
+  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/release-name: fleet
+  hypper.cattle.io/shared-dependencies: |
+    - name: "testdata/testcharts/vanilla-helm"
+      version: "13.3.1"
+      repository: ""

--- a/cmd/hypper/testdata/testcharts/shared-deps/README.md
+++ b/cmd/hypper/testdata/testcharts/shared-deps/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/cmd/hypper/testdata/testcharts/shared-deps/templates/empty.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/cmd/hypper/testdata/testcharts/shared-deps/values.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps/values.yaml
@@ -1,0 +1,1 @@
+Name: my-empty

--- a/cmd/hypper/upgrade.go
+++ b/cmd/hypper/upgrade.go
@@ -17,10 +17,11 @@ limitations under the License.
 package main
 
 import (
+	"time"
+
 	"github.com/Masterminds/log-go"
 	logio "github.com/Masterminds/log-go/io"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -145,7 +146,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 					instClient.Description = client.Description
 					instClient.ReleaseName = client.ReleaseName
 
-					rel, err := runInstall(args, instClient, valueOpts, logger)
+					rel, err := runInstall(args, instClient, valueOpts, logger, settings)
 					if err != nil {
 						return err
 					}

--- a/cmd/hypper/upgrade.go
+++ b/cmd/hypper/upgrade.go
@@ -146,7 +146,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 					instClient.Description = client.Description
 					instClient.ReleaseName = client.ReleaseName
 
-					rel, err := runInstall(args, instClient, valueOpts, logger, settings)
+					rel, err := runInstall(args, instClient, valueOpts, logger)
 					if err != nil {
 						return err
 					}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fatih/color v1.10.0
 	github.com/gofrs/flock v0.8.0
 	github.com/gosuri/uitable v0.0.4
+	github.com/jinzhu/copier v0.2.8
 	github.com/kyokomi/emoji/v2 v2.2.8
 	github.com/mattn/go-shellwords v1.0.11
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/jinzhu/copier v0.2.8 h1:N8MbL5niMwE3P4dOwurJixz5rMkKfujmMRFmAanSzWE=
+github.com/jinzhu/copier v0.2.8/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -107,6 +107,29 @@ func withFallbackAnnotations() chartOption {
 	}
 }
 
+func withMalformedSharedDeps() chartOption {
+	return func(opts *chartOptions) {
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
+		}
+		// this ought to have wrong indentation:
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/shared-dependencies"] = `- name: vanilla-helm
+   version: "0.1.0"
+ repository: "file://testdata/vanilla-helm"`
+	}
+}
+
+func withSharedDeps() chartOption {
+	return func(opts *chartOptions) {
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
+		}
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/shared-dependencies"] = "  - name: \"testdata/charts/vanilla-helm\"" + "\n" +
+			"    version: \"0.1.0\"" + "\n" +
+			"    repository: \"\"" + "\n"
+	}
+}
+
 func withTypeApplication() chartOption {
 	return func(opts *chartOptions) {
 		opts.Chart.Metadata.Type = "application"

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -106,3 +106,15 @@ func withFallbackAnnotations() chartOption {
 		opts.Chart.Metadata.Annotations["catalog.cattle.io/release-name"] = "fleet"
 	}
 }
+
+func withTypeApplication() chartOption {
+	return func(opts *chartOptions) {
+		opts.Chart.Metadata.Type = "application"
+	}
+}
+
+func withTypeLibrary() chartOption {
+	return func(opts *chartOptions) {
+		opts.Chart.Metadata.Type = "library"
+	}
+}

--- a/pkg/action/dependency_shared.go
+++ b/pkg/action/dependency_shared.go
@@ -79,7 +79,7 @@ func (d *SharedDependency) List(chartpath string, logger log.Logger) error {
 
 	c, err := loader.Load(chartpath)
 	if err != nil {
-		fmt.Fprintf(wWarn, "No shared dependencies in %s\n", chartpath)
+		fmt.Fprintf(wWarn, "Failed to load chart in %s\n", chartpath)
 		return err
 	}
 

--- a/pkg/action/dependency_shared.go
+++ b/pkg/action/dependency_shared.go
@@ -52,7 +52,7 @@ func NewSharedDependency(cfg *Configuration) *SharedDependency {
 	}
 }
 
-type yamlDependencies []*chart.Dependency
+type dependencies []*chart.Dependency
 
 // SetNamespace sets the Namespace that should be used in action.SharedDependency
 //
@@ -89,9 +89,9 @@ func (d *SharedDependency) List(chartpath string, logger log.Logger) error {
 		return nil
 	}
 
-	depList := c.Metadata.Annotations["hypper.cattle.io/shared-dependencies"]
-	var yamlDeps yamlDependencies
-	if err = yaml.UnmarshalStrict([]byte(depList), &yamlDeps); err != nil {
+	depYaml := c.Metadata.Annotations["hypper.cattle.io/shared-dependencies"]
+	var deps dependencies
+	if err = yaml.UnmarshalStrict([]byte(depYaml), &deps); err != nil {
 		fmt.Fprintf(wError, "Chart.yaml metadata is malformed for chart %s\n", chartpath)
 		return err
 	}
@@ -105,7 +105,7 @@ func (d *SharedDependency) List(chartpath string, logger log.Logger) error {
 		return err
 	}
 
-	d.printSharedDependencies(chartpath, wInfo, yamlDeps, releases)
+	d.printSharedDependencies(chartpath, wInfo, deps, releases)
 	return nil
 }
 
@@ -125,12 +125,12 @@ func (d *SharedDependency) SharedDependencyStatus(dep *chart.Dependency, release
 }
 
 // printSharedDependencies prints all of the shared dependencies in the yaml file.
-func (d *SharedDependency) printSharedDependencies(chartpath string, out io.Writer, yamlDeps yamlDependencies, releases []*release.Release) {
+func (d *SharedDependency) printSharedDependencies(chartpath string, out io.Writer, deps dependencies, releases []*release.Release) {
 
 	table := uitable.New()
 	table.MaxColWidth = 80
 	table.AddRow("NAME", "VERSION", "REPOSITORY", "STATUS")
-	for _, v := range yamlDeps {
+	for _, v := range deps {
 		table.AddRow(v.Name, v.Version, v.Repository, d.SharedDependencyStatus(v, releases))
 	}
 	fmt.Fprintln(out, table)

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -31,6 +31,9 @@ import (
 type Install struct {
 	*action.Install
 
+	// hypper specific
+	NoSharedDeps bool
+
 	// Config stores the actionconfig so it can be retrieved and used again
 	Config *Configuration
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -22,8 +22,15 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Masterminds/log-go"
+	logio "github.com/Masterminds/log-go/io"
+	"github.com/jinzhu/copier"
+	"github.com/rancher-sandbox/hypper/pkg/cli"
+	"gopkg.in/yaml.v2"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/downloader"
+	"helm.sh/helm/v3/pkg/getter"
 	"helm.sh/helm/v3/pkg/release"
 )
 
@@ -56,7 +63,14 @@ func CheckDependencies(ch *chart.Chart, reqs []*chart.Dependency) error {
 // Run executes the installation
 //
 // If DryRun is set to true, this will prepare the release, but not install it
-func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}) (*release.Release, error) {
+func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}, settings *cli.EnvSettings, logger log.Logger) (*release.Release, error) {
+
+	if !i.NoSharedDeps {
+		if err := i.InstallAllSharedDeps(chrt, settings, logger); err != nil {
+			return nil, err
+		}
+	}
+
 	log.Infof("Installing chart \"%s\" in namespace \"%s\"…", i.ReleaseName, i.Namespace)
 	helmInstall := i.Install
 	rel, err := helmInstall.Run(chrt, vals) // wrap Helm's i.Run for now
@@ -96,4 +110,141 @@ func CheckIfInstallable(ch *chart.Chart) error {
 		return nil
 	}
 	return errors.Errorf("%s charts are not installable", ch.Metadata.Type)
+}
+
+// InstallAllSharedDeps installs all shared dependencies listed in the passed
+// chart.
+//
+// It will check for malformed chart.Metadata.Annotations, and skip those shared
+// dependencies already deployed.
+func (i *Install) InstallAllSharedDeps(chrt *chart.Chart, settings *cli.EnvSettings, logger log.Logger) error {
+
+	if _, ok := chrt.Metadata.Annotations["hypper.cattle.io/shared-dependencies"]; !ok {
+		logger.Debugf("No shared dependencies in %s\n", chrt.Name())
+		return nil
+	}
+
+	depYaml := chrt.Metadata.Annotations["hypper.cattle.io/shared-dependencies"]
+	var deps dependencies
+	if err := yaml.UnmarshalStrict([]byte(depYaml), &deps); err != nil {
+		logger.Errorf("Chart.yaml metadata is malformed for chart %s\n", chrt.Name())
+		return err
+	}
+
+	clientList := NewList(i.Config)
+	clientList.SetStateMask()
+	releases, err := clientList.Run()
+	if err != nil {
+		return err
+	}
+
+	for _, dep := range deps {
+		found := false
+		for _, r := range releases {
+			if r.Name == dep.Name {
+				logger.Infof("Shared dependency %s already installed, not doing anything\n", dep.Name)
+				found = true
+				break // installed, don't keep looking
+			}
+		}
+		if !found {
+			if _, err = i.InstallSharedDep(dep, settings, logger); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// InstallSharedDep installs a chart.Dependency using the provided settings.
+//
+// It does this by creating a new action.Install and setting it correctly,
+// loading the chart, checking for constraints, and delegating the install.Run()
+func (i *Install) InstallSharedDep(dep *chart.Dependency, settings *cli.EnvSettings, logger log.Logger) (*release.Release, error) {
+
+	wInfo := logio.NewWriter(logger, log.InfoLevel)
+
+	clientInstall := NewInstall(i.Config)
+	// we need to automatically satisfy all install options (i.CreateNamespace,
+	// i.DryRun, etc) when we are installing the dep using clientInstall. Doing
+	// a shallow copy sounds like asking for trouble when the install struct
+	// changes, so let's do a deep copy instead:
+	if err := copier.Copy(&clientInstall, &i); err != nil {
+		return nil, err
+	}
+
+	clientInstall.ChartPathOptions.RepoURL = dep.Repository
+	cp, err := clientInstall.ChartPathOptions.LocateChart(dep.Name, settings.EnvSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("CHART PATH: %s\n", cp)
+
+	p := getter.All(settings.EnvSettings)
+	vals := make(map[string]interface{}) // TODO calculate vals instead of {}
+
+	chartRequested, err := loader.Load(cp)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debugf("Original shared-dep chart version: %q", chartRequested.Metadata.Version)
+	if clientInstall.Devel {
+		logger.Debug("setting version to >0.0.0-0")
+		clientInstall.Version = ">0.0.0-0"
+	}
+	// TODO check if chartRequested satisfies version range specified in dep
+
+	// Set Namespace, Releasename for the install client without reevaluating them
+	// from the dependent:
+	SetNamespace(clientInstall, chartRequested, i.Namespace, true)
+	clientInstall.ReleaseName, err = GetName(chartRequested, clientInstall.NameTemplate, dep.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := CheckIfInstallable(chartRequested); err != nil {
+		return nil, err
+	}
+
+	if chartRequested.Metadata.Deprecated {
+		logger.Warn("This chart is deprecated")
+	}
+
+	// Check chart dependencies to make sure all are present in /charts
+	if req := chartRequested.Metadata.Dependencies; req != nil {
+		// If CheckDependencies returns an error, we have unfulfilled dependencies.
+		// As of Helm 2.4.0, this is treated as a stopping condition:
+		// https://github.com/helm/helm/issues/2209
+		if err := action.CheckDependencies(chartRequested, req); err != nil {
+			if clientInstall.DependencyUpdate {
+				man := &downloader.Manager{
+					Out:              wInfo,
+					ChartPath:        cp,
+					Keyring:          clientInstall.ChartPathOptions.Keyring,
+					SkipUpdate:       false,
+					Getters:          p,
+					RepositoryConfig: settings.RepositoryConfig,
+					RepositoryCache:  settings.RepositoryCache,
+					Debug:            settings.Debug,
+				}
+				if err := man.Update(); err != nil {
+					return nil, err
+				}
+				// Reload the chart with the updated Chart.lock file.
+				if chartRequested, err = loader.Load(cp); err != nil {
+					return nil, errors.Wrap(err, "failed reloading chart after repo update")
+				}
+			} else {
+				return nil, err
+			}
+		}
+	}
+
+	res, err := clientInstall.Run(chartRequested, vals, settings, logger)
+	if err != nil {
+		return res, err
+	}
+	return res, nil
 }

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -83,3 +83,14 @@ func (i *Install) Chart(args []string) (string, error) {
 func (i *Install) NameAndChart(args []string) (string, string, error) {
 	return "", "", errors.New("NameAndChart() cannot be used")
 }
+
+// checkIfInstallable validates if a chart can be installed
+//
+// Application chart type is only installable
+func CheckIfInstallable(ch *chart.Chart) error {
+	switch ch.Metadata.Type {
+	case "", "application":
+		return nil
+	}
+	return errors.Errorf("%s charts are not installable", ch.Metadata.Type)
+}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -133,3 +133,18 @@ func TestNameAndChart(t *testing.T) {
 	}
 	is.Equal("NameAndChart() cannot be used", err.Error())
 }
+
+func TestCheckIfInstallable(t *testing.T) {
+	is := assert.New(t)
+
+	// Application chart type is installable
+	err := CheckIfInstallable(buildChart(withTypeApplication()))
+	is.NoError(err)
+
+	// any other chart type besides Application is not installable
+	err = CheckIfInstallable(buildChart(withTypeLibrary()))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	is.Equal("library charts are not installable", err.Error())
+}

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -17,9 +17,15 @@ limitations under the License.
 package action
 
 import (
+	"bytes"
 	"testing"
 
+	"github.com/Masterminds/log-go"
+	logcli "github.com/Masterminds/log-go/impl/cli"
+	"github.com/rancher-sandbox/hypper/internal/test"
+	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/chart"
 )
 
 func installAction(t *testing.T) *Install {
@@ -29,6 +35,130 @@ func installAction(t *testing.T) *Install {
 	instAction.ReleaseName = "test-install-release"
 
 	return instAction
+}
+
+func TestInstallAllSharedDeps(t *testing.T) {
+	for _, tcase := range []struct {
+		name      string
+		chart     *chart.Chart
+		golden    string
+		wantError bool
+		error     string
+		wantDebug bool
+		debug     string
+	}{
+		{
+			name:      "chart has no shared-deps",
+			chart:     buildChart(withHypperAnnotations()),
+			golden:    "output/install-no-shared-deps.txt",
+			wantDebug: true,
+		},
+		{
+			name:      "chart metadata has malformed yaml",
+			chart:     buildChart(withMalformedSharedDeps()),
+			golden:    "output/install-malformed-shared-deps.txt",
+			wantError: true,
+			error:     "yaml: line 2: mapping values are not allowed in this context",
+		},
+		{
+			name:      "dependencies get correctly installed",
+			chart:     buildChart(withHypperAnnotations(), withSharedDeps()),
+			golden:    "output/install-correctly-shared-deps.txt",
+			wantDebug: true,
+		},
+		{
+			name:   "dependencies are already installed",
+			chart:  buildChart(withHypperAnnotations(), withSharedDeps()),
+			golden: "output/install-no-shared-metadata.txt",
+		},
+	} {
+		settings := cli.New()
+		settings.Debug = tcase.wantDebug
+
+		// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
+		buf := new(bytes.Buffer)
+		logger := logcli.NewStandard()
+		logger.InfoOut = buf
+		logger.WarnOut = buf
+		logger.ErrorOut = buf
+		logger.DebugOut = buf
+		if tcase.wantDebug {
+			logger.Level = log.DebugLevel
+		}
+		log.Current = logger
+
+		instAction := installAction(t)
+
+		err := instAction.InstallAllSharedDeps(tcase.chart, settings, log.Current)
+		if (err != nil) != tcase.wantError {
+			t.Errorf("on test %q expected error, got '%v'", tcase.name, err)
+		}
+		if tcase.wantError {
+			is := assert.New(t)
+			is.Equal(tcase.error, err.Error())
+		}
+		if tcase.golden != "" {
+			test.AssertGoldenBytes(t, buf.Bytes(), tcase.golden)
+		}
+	}
+}
+
+func TestInstallSharedDep(t *testing.T) {
+	is := assert.New(t)
+
+	// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
+	buf := new(bytes.Buffer)
+	logger := logcli.NewStandard()
+	logger.InfoOut = buf
+	logger.WarnOut = buf
+	logger.ErrorOut = buf
+	log.Current = logger
+
+	settings := cli.New()
+
+	instAction := installAction(t)
+
+	// TODO dependency version is not satisfied
+
+	// check that install options such as DryRun are passed
+	instAction.DryRun = true
+	dep := &chart.Dependency{
+		Name:       "testdata/charts/vanilla-helm",
+		Repository: "",
+		Version:    "0.1.0",
+	}
+	res, err := instAction.InstallSharedDep(dep, settings, log.Current)
+	instAction.DryRun = false
+	if err != nil {
+		t.Fatalf("Failed install: %s", err)
+	}
+	is.Equal(res.Info.Status.String(), "pending-install", "Expected status of the installed dependency.")
+
+	// install dependency correctly
+	dep = &chart.Dependency{
+		Name:       "testdata/charts/vanilla-helm",
+		Repository: "",
+		Version:    "0.1.0",
+	}
+	res, err = instAction.InstallSharedDep(dep, settings, log.Current)
+	if err != nil {
+		t.Fatalf("Failed install: %s", err)
+	}
+	is.Equal(res.Name, "empty", "Expected release name from dependency.")
+	is.Equal(res.Namespace, "spaced", "Expected parent ns.")
+	is.Equal(res.Info.Status.String(), "deployed", "Expected status of the installed dependency.")
+
+	// install non-existent dependency
+	dep = &chart.Dependency{
+		Name:       "nonexistent-chart",
+		Repository: "",
+		Version:    "0.1.0",
+	}
+	_, err = instAction.InstallSharedDep(dep, settings, log.Current)
+	if err == nil {
+		t.Fatal(err)
+	}
+	is.Equal("failed to download \"nonexistent-chart\" (hint: running `helm repo update` may help)", err.Error())
 }
 
 func TestInstallSetNamespace(t *testing.T) {

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -65,9 +65,9 @@ func TestInstallAllSharedDeps(t *testing.T) {
 			error:     "yaml: line 2: mapping values are not allowed in this context",
 		},
 		{
-			name:      "dependencies get correctly installed",
-			chart:     buildChart(withHypperAnnotations(), withSharedDeps()),
-			golden:    "output/install-correctly-shared-deps.txt",
+			name:   "dependencies get correctly installed",
+			chart:  buildChart(withHypperAnnotations(), withSharedDeps()),
+			golden: "output/install-correctly-shared-deps.txt",
 		},
 		{
 			name:       "dependencies are already installed",

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -68,7 +68,6 @@ func TestInstallAllSharedDeps(t *testing.T) {
 			name:      "dependencies get correctly installed",
 			chart:     buildChart(withHypperAnnotations(), withSharedDeps()),
 			golden:    "output/install-correctly-shared-deps.txt",
-			wantDebug: true,
 		},
 		{
 			name:       "dependencies are already installed",

--- a/pkg/action/testdata/charts/hypper-annot/Chart.yaml
+++ b/pkg/action/testdata/charts/hypper-annot/Chart.yaml
@@ -11,9 +11,6 @@ annotations:
   catalog.cattle.io/namespace: fleet-system
   catalog.cattle.io/release-name: fleet
   hypper.cattle.io/shared-dependencies: |
-    - name: prometheus
-      version: "13.3.1"
-      repository: "https://example.com/charts"
-    - name: postgresql
-      version: "10.3.11"
-      repository: "https://another.example.com/charts"
+    - name: vanilla-helm
+      version: "0.1.0"
+      repository: "file://testdata/vanilla-helm"

--- a/pkg/action/testdata/output/install-correctly-shared-deps.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps.txt
@@ -1,0 +1,4 @@
+DEBUG: CHART PATH: /home/vic/suse/hypper/pkg/action/testdata/charts/vanilla-helm
+DEBUG: Original shared-dep chart version: "0.1.0"
+DEBUG: No shared dependencies in empty
+Installing chart "empty" in namespace "spaced"…

--- a/pkg/action/testdata/output/install-correctly-shared-deps.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps.txt
@@ -1,4 +1,1 @@
-DEBUG: CHART PATH: /home/vic/suse/hypper/pkg/action/testdata/charts/vanilla-helm
-DEBUG: Original shared-dep chart version: "0.1.0"
-DEBUG: No shared dependencies in empty
 Installing chart "empty" in namespace "spaced"…

--- a/pkg/action/testdata/output/install-malformed-shared-deps.txt
+++ b/pkg/action/testdata/output/install-malformed-shared-deps.txt
@@ -1,0 +1,1 @@
+ERROR: Chart.yaml metadata is malformed for chart hello

--- a/pkg/action/testdata/output/install-no-shared-deps.txt
+++ b/pkg/action/testdata/output/install-no-shared-deps.txt
@@ -1,0 +1,1 @@
+DEBUG: No shared dependencies in hello

--- a/pkg/action/testdata/output/install-shared-dep-installed.txt
+++ b/pkg/action/testdata/output/install-shared-dep-installed.txt
@@ -1,1 +1,1 @@
-Shared dependency empty already installed, not doing anything
+Shared dependency testdata/charts/vanilla-helm already installed, not doing anything

--- a/pkg/action/testdata/output/install-shared-dep-installed.txt
+++ b/pkg/action/testdata/output/install-shared-dep-installed.txt
@@ -1,0 +1,1 @@
+Shared dependency empty already installed, not doing anything

--- a/pkg/action/testdata/output/shared-deps-some-deps.txt
+++ b/pkg/action/testdata/output/shared-deps-some-deps.txt
@@ -1,3 +1,2 @@
-NAME      	VERSION	REPOSITORY                        	STATUS       
-prometheus	13.3.1 	https://example.com/charts        	not-installed
-postgresql	10.3.11	https://another.example.com/charts	not-installed
+NAME        	VERSION	REPOSITORY                  	STATUS       
+vanilla-helm	0.1.0  	file://testdata/vanilla-helm	not-installed


### PR DESCRIPTION
This PR adds functionality to install shared-deps of a chart when calling `hypper install CHART`.
This can be skipped with `hypper install CHART --no-shared-deps`.

For now, shared-deps get installed with default values.yaml (they get an empty Values), and there's
no checking that the dependencies satisfy a specific version.

For that, it adds 2 methods to `pkg/action/install.go`: `InstallAddSharedDeps()`, `InstallSharedDep()`.

This implementation introduces duplicated code between `cmd/hypper/install.go.Run()` and
`pkg/action/install.go.{InstallAddSharedDeps(),InstallSharedDep()}.`
In the future,  we can deduplicate the code for loading charts, checking for chart deprecation, and
matching chart versions. I suppose those would go into `pkg/action/install` or `pkg/chart`, or the like.

The implementation also passes `*cli.EnvSettings` from `cmd` to the lib functions, `InstallAddSharedDeps()`, `InstallSharedDep()`. This is needed for being able to locate the chart on the caches, disk, etc.
In the future, we could maybe devise passing it as part of `action.Config`, for example.


fixes: #30 
