### PR TITLE
docs: Link new doc pages, add reference-guides.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,3 +5,6 @@
 - [Quick Start](./user/tutorials/quickstart.md)
 - [How tos](./user/howto/README.md)
     - [Expand a chart with Hypper annotations](./user/howto/expandcharthypper.md)
+    - [Lint charts](./user/howto/lintchart.md)
+    - [Search repos for Hypper charts](./user/howto/search.md)
+- [Reference guides](./reference-guides.md)

--- a/docs/reference-guides.md
+++ b/docs/reference-guides.md
@@ -1,0 +1,5 @@
+# Reference guides
+
+You can find Golang reference guides in
+[pkg.go.dev/github.com/rancher-sandbox/hypper](https://pkg.go.dev/github.com/rancher-sandbox/hypper),
+particularly for the [Hypper library API](https://pkg.go.dev/github.com/rancher-sandbox/hypper/pkg).


### PR DESCRIPTION
Rendered: https://github.com/rancher-sandbox/hypper/blob/link-doc-pages/docs/SUMMARY.md