### PR TITLE
Set proper dir for publishing docs

### DIFF
--- a/.github/workflows/docs-book.yml
+++ b/.github/workflows/docs-book.yml
@@ -34,4 +34,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./book
+          publish_dir: ./book/html


### PR DESCRIPTION
Because now we are using the linkchecker output for testing
the docs link validation, mdbook finds 2 different outputs
and tries to ensure that each output gets its own directory
thus now we have to set the specific html dir where the
output is dumped on

Signed-off-by: Itxaka <igarcia@suse.com>