### PR TITLE
fix: Honour annotations' namespaces of shared-deps

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -217,7 +217,7 @@ func (i *Install) InstallSharedDep(dep *chart.Dependency, settings *cli.EnvSetti
 
 	// Set Namespace, Releasename for the install client without reevaluating them
 	// from the dependent:
-	SetNamespace(clientInstall, chartRequested, i.Namespace, true)
+	SetNamespace(clientInstall, chartRequested, i.Namespace, false)
 	clientInstall.ReleaseName, err = GetName(chartRequested, clientInstall.NameTemplate, dep.Name)
 	if err != nil {
 		return nil, err

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -194,6 +194,20 @@ func TestInstallSharedDep(t *testing.T) {
 	is.Equal(res.Namespace, "spaced", "Expected parent ns.")
 	is.Equal(res.Info.Status.String(), "deployed", "Expected status of the installed dependency.")
 
+	// install dependency correctly, following its own annotations
+	dep = &chart.Dependency{
+		Name:       "testdata/charts/shared-dep",
+		Repository: "",
+		Version:    "0.1.0",
+	}
+	res, err = instAction.InstallSharedDep(dep, settings, log.Current, 0)
+	if err != nil {
+		t.Fatalf("Failed install: %s", err)
+	}
+	is.Equal(res.Name, "my-shared-dep", "Expected release name from dependency.")
+	is.Equal(res.Namespace, "my-shared-dep-ns", "Expected shared-dep ns.")
+	is.Equal(res.Info.Status.String(), "deployed", "Expected status of the installed dependency.")
+
 	// install non-existent dependency
 	dep = &chart.Dependency{
 		Name:       "nonexistent-chart",

--- a/pkg/action/testdata/charts/hypper-annot/Chart.yaml
+++ b/pkg/action/testdata/charts/hypper-annot/Chart.yaml
@@ -11,6 +11,6 @@ annotations:
   catalog.cattle.io/namespace: fleet-system
   catalog.cattle.io/release-name: fleet
   hypper.cattle.io/shared-dependencies: |
-    - name: vanilla-helm
+    - name: shared-dep
       version: "0.1.0"
-      repository: "file://testdata/vanilla-helm"
+      repository: "file://testdata/shared-dep"

--- a/pkg/action/testdata/charts/shared-dep/Chart.yaml
+++ b/pkg/action/testdata/charts/shared-dep/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Empty shared-dep chart
+home: https://helm.sh/helm
+name: shared-dep-empty
+sources:
+  - https://github.com/rancher-sandbox/hypper
+version: 0.1.0
+annotations:
+  hypper.cattle.io/namespace: my-shared-dep-ns
+  hypper.cattle.io/release-name: my-shared-dep

--- a/pkg/action/testdata/charts/shared-dep/README.md
+++ b/pkg/action/testdata/charts/shared-dep/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/pkg/action/testdata/charts/shared-dep/templates/empty.yaml
+++ b/pkg/action/testdata/charts/shared-dep/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/pkg/action/testdata/charts/shared-dep/values.yaml
+++ b/pkg/action/testdata/charts/shared-dep/values.yaml
@@ -1,0 +1,1 @@
+Name: shared-dep-empty

--- a/pkg/action/testdata/output/shared-deps-some-deps.txt
+++ b/pkg/action/testdata/output/shared-deps-some-deps.txt
@@ -1,2 +1,2 @@
-NAME        	VERSION	REPOSITORY                  	STATUS       
-vanilla-helm	0.1.0  	file://testdata/vanilla-helm	not-installed
+NAME      	VERSION	REPOSITORY                	STATUS       
+shared-dep	0.1.0  	file://testdata/shared-dep	not-installed


### PR DESCRIPTION
Correctly install shared-deps in their own specified namespaces.