### PR TITLE
Check for field differences in our settings

### DIFF
--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -179,7 +179,7 @@ func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 func (s *EnvSettings) checkCorrectHelmSettings() error {
 	helmSettings := reflect.TypeOf(cli.EnvSettings{})
 	helmNumFields := helmSettings.NumField()
-	hypperSettings := reflect.TypeOf(EnvSettings{EnvSettings: nil})
+	hypperSettings := reflect.TypeOf(EnvSettings{})
 	for i := 0; i < helmNumFields; i++ {
 		field := helmSettings.Field(i)
 		_, found := hypperSettings.FieldByName(field.Name)

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -25,7 +25,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -169,22 +168,6 @@ func (s *EnvSettings) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RepositoryConfig, "repository-config", s.RepositoryConfig, "path to the file containing repository names and URLs")
 	fs.StringVar(&s.RepositoryCache, "repository-cache", s.RepositoryCache, "path to the file containing cached repository indexes")
 
-}
-
-// checkCorrectHelmSettings checks that we have the same fields in our hypper settings as
-// there are in the helm settings. If we are missing something we return an error
-func (s *EnvSettings) checkCorrectHelmSettings() error {
-	helmSettings := reflect.TypeOf(cli.EnvSettings{})
-	helmNumFields := helmSettings.NumField()
-	hypperSettings := reflect.TypeOf(EnvSettings{})
-	for i := 0; i < helmNumFields; i++ {
-		field := helmSettings.Field(i)
-		_, found := hypperSettings.FieldByName(field.Name)
-		if !found {
-			return fmt.Errorf("field %v from Helm cli.Settings not found in our settings", field.Name)
-		}
-	}
-	return nil
 }
 
 func envOr(name, def string) string {

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -24,7 +24,6 @@ package cli
 
 import (
 	"fmt"
-	"github.com/Masterminds/log-go"
 	"os"
 	"reflect"
 	"strconv"
@@ -104,10 +103,6 @@ func New() *EnvSettings {
 		NoEmojis: false,
 	}
 
-	if err := env.checkCorrectHelmSettings(); err != nil {
-		log.Fatal(err)
-		os.Exit(1)
-	}
 	os.Setenv("HELM_NAMESPACE", env.namespace) // WHY???
 
 	// Create default helm settings and propagate our default hypper values

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -39,8 +39,10 @@ import (
 // defaultMaxHistory sets the maximum number of releases to 0: unlimited
 const defaultMaxHistory = 10
 
-// EnvSettings is a composite type of helm.pkg.env.EnvSettings.
-// describes all of the environment settings.
+// EnvSettings describes all of the environment settings.
+// It contains a pointer to Helm settings for functions that need that exact type
+// We overwrite all of the helm settings values with our own on New so it contains the same
+// config settings
 type EnvSettings struct {
 	EnvSettings *cli.EnvSettings
 

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/cli"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -114,9 +117,34 @@ func TestEnvSettings(t *testing.T) {
 }
 
 func TestHelmFields(t *testing.T) {
-	env := EnvSettings{}
-	if err := env.checkCorrectHelmSettings(); err != nil {
-		t.Fatal(err)
+
+	helmSettings := reflect.TypeOf(cli.EnvSettings{})
+	helmNumFields := helmSettings.NumField()
+	hypperSettings := reflect.TypeOf(EnvSettings{})
+	for i := 0; i < helmNumFields; i++ {
+		field := helmSettings.Field(i)
+		_, found := hypperSettings.FieldByName(field.Name)
+		if !found {
+			t.Fatalf("field %v from Helm cli.Settings not found in our settings", field.Name)
+		}
+	}
+
+	// Composite type of helm EnvSettings plus an extra field
+	type FakeSettings struct {
+		*cli.EnvSettings
+		missingField string
+	}
+
+	helmSettings = reflect.TypeOf(FakeSettings{})
+	helmNumFields = helmSettings.NumField()
+	hypperSettings = reflect.TypeOf(EnvSettings{})
+	for i := 0; i < helmNumFields; i++ {
+		field := helmSettings.Field(i)
+		_, found := hypperSettings.FieldByName(field.Name)
+		if !found {
+			// If we fail, make sure that the error is due to our known missing field
+			assert.Equal(t, field.Name, "missingField")
+		}
 	}
 }
 

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -113,6 +113,13 @@ func TestEnvSettings(t *testing.T) {
 	}
 }
 
+func TestHelmFields(t *testing.T) {
+	env := EnvSettings{}
+	if err := env.checkCorrectHelmSettings(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func resetEnv() func() {
 	origEnv := os.Environ()
 

--- a/pkg/cli/environment_test.go
+++ b/pkg/cli/environment_test.go
@@ -132,7 +132,7 @@ func TestHelmFields(t *testing.T) {
 	// Composite type of helm EnvSettings plus an extra field
 	type FakeSettings struct {
 		*cli.EnvSettings
-		missingField string
+		missingField string //nolint
 	}
 
 	helmSettings = reflect.TypeOf(FakeSettings{})


### PR DESCRIPTION
Remove helm settings as composite to avoid propagation of
new fields into our settings automatically
Doesnt really matter as we are overwritting all fields
with our own values
Adds a checker to check that we are not missing any fields

Signed-off-by: Itxaka <igarcia@suse.com>