### PR TITLE
Fix get_hypper after shellcheck update

### DIFF
--- a/scripts/get-hypper
+++ b/scripts/get-hypper
@@ -88,7 +88,7 @@ verifySupported() {
 
 # checkDesiredVersion checks if the desired version is available.
 checkDesiredVersion() {
-  if [ "x$DESIRED_VERSION" == "x" ]; then
+  if [ "$DESIRED_VERSION" == "" ]; then
     # Get tag from release URL
     local latest_release_url="https://api.github.com/repos/rancher-sandbox/hypper/releases/latest"
     if [ "${HAS_CURL}" == "true" ]; then


### PR DESCRIPTION
This PR fixes the following issue with shellcheck:
```
==> Checking shell scripts <==
shellcheck ./scripts/*

In ./scripts/get-hypper line 91:
  if [ "x$DESIRED_VERSION" == "x" ]; then
       ^-----------------^ SC2268: Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean: 
  if [ "$DESIRED_VERSION" == "" ]; then

For more information:
  https://www.shellcheck.net/wiki/SC2268 -- Avoid x-prefix in comparisons as ...
make: *** [Makefile:92: shellcheck] Error 1
```