### PR TITLE
feat: Add semver range support to all cmd & pkg

### DIFF
--- a/cmd/hypper/dependency_shared_test.go
+++ b/cmd/hypper/dependency_shared_test.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/rancher-sandbox/hypper/pkg/chart"
 	"helm.sh/helm/v3/pkg/release"
 )
 
@@ -46,27 +47,56 @@ func TestSharedDependencyListCmd(t *testing.T) {
 		name:   "Shared dependencies installed in correct ns",
 		cmd:    "shared-deps list testdata/testcharts/shared-deps",
 		golden: "output/shared-deps-list-installed.txt",
-		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "my-shared-dep", Namespace: "my-shared-dep-ns"})},
+		rels: []*release.Release{release.Mock(&release.MockReleaseOptions{
+			Name:      "my-shared-dep",
+			Namespace: "my-shared-dep-ns",
+			Chart: chart.Mock(&chart.MockChartOptions{
+				Name:    "shared-dep-empty",
+				Version: "0.1.1",
+			}),
+		})},
 	}
 
 	sharedDependenciesInstalledDiffNS := cmdTestCase{
 		name:   "Shared dependencies installed in different ns, and not finding them",
 		cmd:    "shared-deps list testdata/testcharts/shared-deps",
 		golden: "output/shared-deps-list-installed-diff-ns.txt",
-		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "my-shared-dep", Namespace: "other-ns"})},
+		rels: []*release.Release{release.Mock(&release.MockReleaseOptions{
+			Name:      "my-shared-dep",
+			Namespace: "other-ns",
+			Chart: chart.Mock(&chart.MockChartOptions{
+				Name:    "shared-dep-empty",
+				Version: "0.1.1",
+			}),
+		})},
 	}
 
 	sharedDependenciesInstalledDiffNSFlag := cmdTestCase{
 		name:   "Shared dependencies installed in different ns, passing -n flag to find them",
-		cmd:    "shared-deps list testdata/testcharts/shared-deps -n my-shared-dep-ns",
+		cmd:    "shared-deps list testdata/testcharts/shared-deps -n ns-from-flag",
 		golden: "output/shared-deps-list-installed-diff-ns-found.txt",
-		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "my-shared-dep", Namespace: "my-shared-dep-ns"})},
+		rels: []*release.Release{release.Mock(&release.MockReleaseOptions{
+			Name:      "my-shared-dep",
+			Namespace: "ns-from-flag",
+			Chart: chart.Mock(&chart.MockChartOptions{
+				Name:    "shared-dep-empty",
+				Version: "0.1.1",
+			}),
+		})},
 	}
+
 	sharedDependenciesInstalledDiffNSFlagNotFound := cmdTestCase{
 		name:   "Shared dependencies installed in different ns, passing -n flag with incorrect ns and not finding them",
-		cmd:    "shared-deps list testdata/testcharts/shared-deps -n my-shared-dep-ns",
+		cmd:    "shared-deps list testdata/testcharts/shared-deps -n ns-from-flag",
 		golden: "output/shared-deps-list-installed-diff-ns-not-found.txt",
-		rels:   []*release.Release{release.Mock(&release.MockReleaseOptions{Name: "my-shared-dep", Namespace: "other-ns"})},
+		rels: []*release.Release{release.Mock(&release.MockReleaseOptions{
+			Name:      "my-shared-dep",
+			Namespace: "ns-from-flag-not-found",
+			Chart: chart.Mock(&chart.MockChartOptions{
+				Name:    "shared-dep-empty",
+				Version: "0.1.1",
+			}),
+		})},
 	}
 
 	if runtime.GOOS == "windows" {
@@ -74,7 +104,8 @@ func TestSharedDependencyListCmd(t *testing.T) {
 		noSharedDependencies.golden = "output/shared-deps-list-no-shared-deps-windows.txt"
 	}
 
-	tests := []cmdTestCase{noSuchChart,
+	tests := []cmdTestCase{
+		noSuchChart,
 		noSharedDependencies,
 		noSharedDependenciesInstalled,
 		sharedDependenciesInstalled,

--- a/cmd/hypper/dependency_shared_test.go
+++ b/cmd/hypper/dependency_shared_test.go
@@ -99,6 +99,20 @@ func TestSharedDependencyListCmd(t *testing.T) {
 		})},
 	}
 
+	sharedDependenciesInstalledVersionOutOfRange := cmdTestCase{
+		name:   "Shared dependencies installed, semver out of range",
+		cmd:    "shared-deps list testdata/testcharts/shared-deps -n my-shared-dep-ns",
+		golden: "output/shared-deps-list-installed-out-of-range.txt",
+		rels: []*release.Release{release.Mock(&release.MockReleaseOptions{
+			Name:      "my-shared-dep",
+			Namespace: "my-shared-dep-ns",
+			Chart: chart.Mock(&chart.MockChartOptions{
+				Name:    "my-shared-dep",
+				Version: "3.1.0",
+			}),
+		})},
+	}
+
 	if runtime.GOOS == "windows" {
 		noSuchChart.golden = "output/shared-deps-list-no-chart-windows.txt"
 		noSharedDependencies.golden = "output/shared-deps-list-no-shared-deps-windows.txt"
@@ -112,6 +126,7 @@ func TestSharedDependencyListCmd(t *testing.T) {
 		sharedDependenciesInstalledDiffNS,
 		sharedDependenciesInstalledDiffNSFlag,
 		sharedDependenciesInstalledDiffNSFlagNotFound,
+		sharedDependenciesInstalledVersionOutOfRange,
 	}
 	runTestCmd(t, tests)
 }

--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -65,7 +65,7 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 			if err != nil {
 				return err
 			}
-			logger.Info(eyecandy.ESPrint(settings.NoEmojis, ":clapping_hands: Done!"))
+			logger.Info(eyecandy.ESPrint(settings.NoEmojis, ":clapping_hands:Done!"))
 			return nil
 		},
 	}

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -71,6 +71,13 @@ func TestInstallCmd(t *testing.T) {
 			cmd:    "install testdata/testcharts/shared-deps",
 			golden: "output/install-with-shared-deps.txt",
 		},
+		// Install, with shared deps out-of-range
+		{
+			name:      "install, with shared deps out-of-range",
+			cmd:       "install testdata/testcharts/shared-deps-out-of-range",
+			golden:    "output/install-with-shared-deps-out-of-range.txt",
+			wantError: true,
+		},
 	}
 	runTestActionCmd(t, tests)
 }

--- a/cmd/hypper/testdata/output/install-create-namespace.txt
+++ b/cmd/hypper/testdata/output/install-create-namespace.txt
@@ -1,2 +1,2 @@
-🛳 : Installing chart "empty" as "purple" in namespace "deep"…
-👏  Done!
+🛳  Installing chart "empty" as "purple" in namespace "deep"…
+👏 Done!

--- a/cmd/hypper/testdata/output/install-fallback-annot.txt
+++ b/cmd/hypper/testdata/output/install-fallback-annot.txt
@@ -1,2 +1,2 @@
-🛳 : Installing chart "empty" as "fleet" in namespace "fleet-system"…
-👏  Done!
+🛳  Installing chart "empty" as "fleet" in namespace "fleet-system"…
+👏 Done!

--- a/cmd/hypper/testdata/output/install-hypper-annot.txt
+++ b/cmd/hypper/testdata/output/install-hypper-annot.txt
@@ -1,2 +1,2 @@
-🛳 : Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
-👏  Done!
+🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
+👏 Done!

--- a/cmd/hypper/testdata/output/install-name-ns-args.txt
+++ b/cmd/hypper/testdata/output/install-name-ns-args.txt
@@ -1,2 +1,2 @@
-🛳 : Installing chart "empty" as "zeppelin" in namespace "led"…
-👏  Done!
+🛳  Installing chart "empty" as "zeppelin" in namespace "led"…
+👏 Done!

--- a/cmd/hypper/testdata/output/install-no-name-or-annot.txt
+++ b/cmd/hypper/testdata/output/install-no-name-or-annot.txt
@@ -1,2 +1,2 @@
-🛳 : Installing chart "empty" as "empty" in namespace "default"…
-👏  Done!
+🛳  Installing chart "empty" as "empty" in namespace "default"…
+👏 Done!

--- a/cmd/hypper/testdata/output/install-with-shared-deps-out-of-range.txt
+++ b/cmd/hypper/testdata/output/install-with-shared-deps-out-of-range.txt
@@ -1,0 +1,3 @@
+🛳  Installing shared dependencies for chart "empty":
+ERROR: ❌  Satisfiable version for chart "testdata/testcharts/shared-dep" not found, aborting
+Error: Satisfiable chart version not found; 0.1.0 is less than 0.3.0

--- a/cmd/hypper/testdata/output/install-with-shared-deps.txt
+++ b/cmd/hypper/testdata/output/install-with-shared-deps.txt
@@ -1,4 +1,4 @@
 🛳  Installing shared dependencies for chart "empty":
-🛳 : - Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
-🛳 : Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
-👏  Done!
+🛳  - Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
+🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
+👏 Done!

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-found.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-found.txt
@@ -1,2 +1,2 @@
-NAME            	VERSION	REPOSITORY	STATUS  	NAMESPACE       
-shared-dep-empty	0.1.0  	          	deployed	my-shared-dep-ns
+NAME            	VERSION	REPOSITORY	STATUS  	NAMESPACE   
+shared-dep-empty	~0.1.0 	          	deployed	ns-from-flag

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-not-found.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns-not-found.txt
@@ -1,2 +1,2 @@
-NAME            	VERSION	REPOSITORY	STATUS       	NAMESPACE       
-shared-dep-empty	0.1.0  	          	not-installed	my-shared-dep-ns
+NAME            	VERSION	REPOSITORY	STATUS       	NAMESPACE   
+shared-dep-empty	~0.1.0 	          	not-installed	ns-from-flag

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-diff-ns.txt
@@ -1,2 +1,2 @@
 NAME            	VERSION	REPOSITORY	STATUS       	NAMESPACE       
-shared-dep-empty	0.1.0  	          	not-installed	my-shared-dep-ns
+shared-dep-empty	~0.1.0 	          	not-installed	my-shared-dep-ns

--- a/cmd/hypper/testdata/output/shared-deps-list-installed-out-of-range.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed-out-of-range.txt
@@ -1,0 +1,2 @@
+NAME            	VERSION	REPOSITORY	STATUS      	NAMESPACE       
+shared-dep-empty	~0.1.0 	          	out-of-range	my-shared-dep-ns

--- a/cmd/hypper/testdata/output/shared-deps-list-installed.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-installed.txt
@@ -1,2 +1,2 @@
 NAME            	VERSION	REPOSITORY	STATUS  	NAMESPACE       
-shared-dep-empty	0.1.0  	          	deployed	my-shared-dep-ns
+shared-dep-empty	~0.1.0 	          	deployed	my-shared-dep-ns

--- a/cmd/hypper/testdata/output/shared-deps-list-not-installed.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-not-installed.txt
@@ -1,2 +1,2 @@
 NAME            	VERSION	REPOSITORY	STATUS       	NAMESPACE       
-shared-dep-empty	0.1.0  	          	not-installed	my-shared-dep-ns
+shared-dep-empty	~0.1.0 	          	not-installed	my-shared-dep-ns

--- a/cmd/hypper/testdata/output/upgrade-with-install-release-name.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-install-release-name.txt
@@ -1,5 +1,5 @@
 🧰  Release "jojo" does not exist. Installing it now.
-🛳 : Installing chart "funny-bunny" as "jojo" in namespace "default"…
+🛳  Installing chart "funny-bunny" as "jojo" in namespace "default"…
 NAME: jojo
 LAST DEPLOYED: Fri Sep  2 22:04:05 1977
 NAMESPACE: default

--- a/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/Chart.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+description: Empty testing chart
+home: https://helm.sh/helm
+name: empty
+sources:
+  - https://github.com/helm/helm
+version: 0.1.0
+annotations:
+  hypper.cattle.io/namespace: hypper
+  hypper.cattle.io/release-name: my-hypper-name
+  catalog.cattle.io/namespace: fleet-system
+  catalog.cattle.io/release-name: fleet
+  hypper.cattle.io/shared-dependencies: |
+    - name: "testdata/testcharts/shared-dep"
+      version: "~0.3.0"
+      repository: ""

--- a/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/README.md
+++ b/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/README.md
@@ -1,0 +1,3 @@
+#Empty
+
+This space intentionally left blank.

--- a/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/templates/empty.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/templates/empty.yaml
@@ -1,0 +1,1 @@
+# This file is intentionally blank

--- a/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/values.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps-out-of-range/values.yaml
@@ -1,0 +1,1 @@
+Name: my-empty

--- a/cmd/hypper/testdata/testcharts/shared-deps/Chart.yaml
+++ b/cmd/hypper/testdata/testcharts/shared-deps/Chart.yaml
@@ -12,5 +12,5 @@ annotations:
   catalog.cattle.io/release-name: fleet
   hypper.cattle.io/shared-dependencies: |
     - name: "testdata/testcharts/shared-dep"
-      version: "0.1.0"
+      version: "~0.1.0"
       repository: ""

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -153,18 +153,24 @@ func withTypeLibrary() chartOption {
 	}
 }
 
-// func withHypperAnnotValues(name string, ns string) chartOption {
-// 	return func(opts *chartOptions) {
-// 		if opts.Chart.Metadata.Annotations == nil {
-// 			opts.Chart.Metadata.Annotations = make(map[string]string)
-// 		}
-// 		opts.Chart.Metadata.Annotations["hypper.cattle.io/namespace"] = ns
-// 		opts.Chart.Metadata.Annotations["hypper.cattle.io/release-name"] = name
-// 	}
-// }
+func withHypperAnnotValues(name string, ns string) chartOption {
+	return func(opts *chartOptions) {
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
+		}
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/namespace"] = ns
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/release-name"] = name
+	}
+}
 
-// func withName(name string) chartOption {
-// 	return func(opts *chartOptions) {
-// 		opts.Metadata.Name = name
-// 	}
-// }
+func withName(name string) chartOption {
+	return func(opts *chartOptions) {
+		opts.Metadata.Name = name
+	}
+}
+
+func withChartVersion(semver string) chartOption {
+	return func(opts *chartOptions) {
+		opts.Metadata.Version = semver
+	}
+}

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -130,6 +130,17 @@ func withSharedDeps() chartOption {
 	}
 }
 
+func withOutOfRangeSharedDeps() chartOption {
+	return func(opts *chartOptions) {
+		if opts.Chart.Metadata.Annotations == nil {
+			opts.Chart.Metadata.Annotations = make(map[string]string)
+		}
+		opts.Chart.Metadata.Annotations["hypper.cattle.io/shared-dependencies"] = "  - name: \"testdata/charts/shared-dep\"" + "\n" +
+			"    version: \"1.1.0\"" + "\n" +
+			"    repository: \"\"" + "\n"
+	}
+}
+
 func withTypeApplication() chartOption {
 	return func(opts *chartOptions) {
 		opts.Chart.Metadata.Type = "application"

--- a/pkg/action/dependency_shared.go
+++ b/pkg/action/dependency_shared.go
@@ -138,8 +138,14 @@ func (d *SharedDependency) printSharedDependencies(chartpath string, logger log.
 			return err
 		}
 
-		// obtain the dep ns: either shared-dep has annotations, or the parent has, or we use the default ns
-		depNS := GetNamespace(depChart, GetNamespace(depChart, settings.Namespace()))
+		// calculate which ns corresponds to the dependency
+		var depNS string
+		if settings.NamespaceFromFlag {
+			depNS = settings.Namespace()
+		} else {
+			// either shared-dep has annotations, or the parent has, or we use the default ns
+			depNS = GetNamespace(depChart, GetNamespace(depChart, settings.Namespace()))
+		}
 		d.Config.SetNamespace(depNS)
 
 		if settings.NamespaceFromFlag && settings.Namespace() != depNS {

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -83,7 +83,7 @@ func (i *Install) Run(chrt *chart.Chart, vals map[string]interface{}, settings *
 	if lvl > 0 {
 		prefix = fmt.Sprintf("%*s", lvl*2, "- ")
 	}
-	logger.Infof(eyecandy.ESPrintf(settings.NoEmojis, ":cruise_ship:: %sInstalling chart \"%s\" as \"%s\" in namespace \"%s\"…", prefix, chrt.Name(), i.ReleaseName, i.Namespace))
+	logger.Infof(eyecandy.ESPrintf(settings.NoEmojis, ":cruise_ship: %sInstalling chart \"%s\" as \"%s\" in namespace \"%s\"…", prefix, chrt.Name(), i.ReleaseName, i.Namespace))
 	helmInstall := i.Install
 	i.Config.SetNamespace(i.Namespace)
 	rel, err := helmInstall.Run(chrt, vals) // wrap Helm's i.Run for now

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/Masterminds/log-go"
 	logio "github.com/Masterminds/log-go/io"
+	"github.com/Masterminds/semver/v3"
 	"github.com/jinzhu/copier"
 	"github.com/rancher-sandbox/hypper/pkg/cli"
 	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
@@ -174,8 +175,26 @@ func (i *Install) InstallAllSharedDeps(chrt *chart.Chart, settings *cli.EnvSetti
 			return err
 		}
 
+		// create constraint for version checking
+		constraint, err := semver.NewConstraint(dep.Version)
+		if err != nil {
+			return err
+		}
+
 		for _, r := range releases {
 			if r.Name == name && r.Namespace == ns {
+				v, err := semver.NewVersion(r.Chart.Metadata.Version)
+				if err != nil {
+					return err
+				}
+				if b, errs := constraint.Validate(v); !b {
+					logger.Errorf(eyecandy.ESPrintf(settings.NoEmojis, ":x: %sShared dependency chart \"%s\" already installed in an unsatisfiable version, aborting\n", prefix, dep.Name))
+					err := errors.New("Shared dep version out of range")
+					for _, e := range errs {
+						err = fmt.Errorf("%w; %s", err, e)
+					}
+					return err
+				}
 				logger.Infof(eyecandy.ESPrintf(settings.NoEmojis, ":information_source: %sShared dependency chart \"%s\" already installed, skipping\n", prefix, dep.Name))
 				found = true
 				break // installed, don't keep looking
@@ -237,7 +256,28 @@ func (i *Install) InstallSharedDep(dep *chart.Dependency, settings *cli.EnvSetti
 		logger.Debug("setting version to >0.0.0-0")
 		clientInstall.Version = ">0.0.0-0"
 	}
-	// TODO check if chartRequested satisfies version range specified in dep
+
+	// check if chartRequested satisfies version range specified in dep
+	if chartRequested.Metadata.Version != dep.Version {
+		constraint, err := semver.NewConstraint(dep.Version)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := semver.NewVersion(chartRequested.Metadata.Version)
+		if err != nil {
+			return nil, err
+		}
+
+		if b, errs := constraint.Validate(v); !b {
+			logger.Errorf(eyecandy.ESPrintf(settings.NoEmojis, ":x: Satisfiable version for chart \"%s\" not found, aborting\n", dep.Name))
+			err := errors.New("Satisfiable chart version not found")
+			for _, e := range errs {
+				err = fmt.Errorf("%w; %s", err, e)
+			}
+			return nil, err
+		}
+	}
 
 	// Set Namespace, Releasename for the install client without reevaluating them
 	// from the dependent:

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -177,7 +177,7 @@ func TestInstallSharedDep(t *testing.T) {
 			name: "dep installed correctly",
 			dep: &chart.Dependency{
 				Name:       "testdata/charts/vanilla-helm",
-				Version:    "0.1.0",
+				Version:    "^0.1.0",
 				Repository: "",
 			},
 			status:  "deployed",
@@ -188,7 +188,7 @@ func TestInstallSharedDep(t *testing.T) {
 			name: "dep with annot installed correctly",
 			dep: &chart.Dependency{
 				Name:       "testdata/charts/shared-dep",
-				Version:    "0.1.0",
+				Version:    "~0.1.0",
 				Repository: "",
 			},
 			status:  "deployed",
@@ -204,6 +204,26 @@ func TestInstallSharedDep(t *testing.T) {
 			},
 			wantError: true,
 			error:     "failed to download \"nonexistent-chart\" (hint: running `helm repo update` may help)",
+		},
+		{
+			name: "shared-dep version cannot be found",
+			dep: &chart.Dependency{
+				Name:       "testdata/charts/shared-dep",
+				Version:    "1.1.0",
+				Repository: "",
+			},
+			wantError: true,
+			error:     "Satisfiable chart version not found; 0.1.0 is not equal to 1.1.0",
+		},
+		{
+			name: "shared-dep version non-parseable",
+			dep: &chart.Dependency{
+				Name:       "testdata/charts/shared-dep",
+				Version:    "foo0.1.0",
+				Repository: "",
+			},
+			wantError: true,
+			error:     "improper constraint: foo0.1.0",
 		},
 	} {
 		is := assert.New(t)

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -127,6 +127,7 @@ func TestInstallAllSharedDeps(t *testing.T) {
 				},
 				Version:   1,
 				Namespace: "my-shared-dep-ns",
+				Chart:     buildChart(),
 			}
 			instAction.Config.SetNamespace("spaced")
 			err := instAction.Config.Releases.Create(rel)

--- a/pkg/action/install_test.go
+++ b/pkg/action/install_test.go
@@ -97,6 +97,14 @@ func TestInstallAllSharedDeps(t *testing.T) {
 			golden:     "output/install-shared-dep-installed.txt",
 			addRelStub: true,
 		},
+		{
+			name:       "dependencies are already installed in out-of-range ver",
+			chart:      buildChart(withHypperAnnotations(), withOutOfRangeSharedDeps()),
+			golden:     "output/install-shared-dep-installed-out-of-range.txt",
+			addRelStub: true,
+			wantError:  true,
+			error:      "Shared dep version out of range; 0.1.0 is not equal to 1.1.0",
+		},
 	} {
 		settings := cli.New()
 		settings.Debug = tcase.wantDebug

--- a/pkg/action/testdata/output/install-correctly-shared-deps.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps.txt
@@ -1,2 +1,2 @@
 🛳  Installing shared dependencies for chart "hello":
-🛳 : - Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
+🛳  - Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…

--- a/pkg/action/testdata/output/install-shared-dep-installed-out-of-range.txt
+++ b/pkg/action/testdata/output/install-shared-dep-installed-out-of-range.txt
@@ -1,0 +1,2 @@
+🛳  Installing shared dependencies for chart "hello":
+ERROR: ❌  - Shared dependency chart "testdata/charts/shared-dep" already installed in an unsatisfiable version, aborting

--- a/pkg/chart/mock.go
+++ b/pkg/chart/mock.go
@@ -1,0 +1,39 @@
+// Copyright SUSE LLC.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chart
+
+import (
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+// MockChartOptions allows for user-configurable options on mock chart objects.
+type MockChartOptions struct {
+	Name    string
+	Version string
+}
+
+// Mock creates a mock chart object based on options set by MockChartOptions.
+// This function should typically not be used outside of testing.
+func Mock(opts *MockChartOptions) *chart.Chart {
+	return &chart.Chart{
+		Metadata: &chart.Metadata{
+			Name:       opts.Name,
+			Version:    opts.Version,
+			AppVersion: "1.0",
+		},
+		Templates: []*chart.File{
+			{Name: "templates/hello", Data: []byte("hello: world")},
+		},
+	}
+}

--- a/pkg/cli/environment.go
+++ b/pkg/cli/environment.go
@@ -84,7 +84,6 @@ type EnvSettings struct {
 
 // New is a constructor of EnvSettings
 func New() *EnvSettings {
-	// TODO check with reflection that we are not missing any field
 	env := &EnvSettings{
 		namespace:        os.Getenv("HYPPER_NAMESPACE"),
 		MaxHistory:       envIntOr("HYPPER_MAX_HISTORY", defaultMaxHistory),

--- a/pkg/lint/rules/annotations.go
+++ b/pkg/lint/rules/annotations.go
@@ -72,9 +72,9 @@ func validateChartHypperSharedDeps(chart *helmChart.Metadata) error {
 
 // validateChartHypperSharedDepsCorrect checks that shared deps are in the correct format
 func validateChartHypperSharedDepsCorrect(chart *helmChart.Metadata) error {
-	depList := chart.Annotations["hypper.cattle.io/shared-dependencies"]
-	var yamlDeps []*helmChart.Dependency
-	if err := yaml.UnmarshalStrict([]byte(depList), &yamlDeps); err != nil {
+	depYaml := chart.Annotations["hypper.cattle.io/shared-dependencies"]
+	var deps []*helmChart.Dependency
+	if err := yaml.UnmarshalStrict([]byte(depYaml), &deps); err != nil {
 		return errors.New("Shared dependencies list is broken, please check the correct format")
 	}
 	return nil

--- a/pkg/lint/rules/annotations_test.go
+++ b/pkg/lint/rules/annotations_test.go
@@ -65,3 +65,33 @@ func TestValidateChartHypperRelease(t *testing.T) {
 	}
 
 }
+
+func TestValidateChartHypperSharedDepsCorrect(t *testing.T) {
+	annotations := map[string]string{
+		"hypper.cattle.io/release-name": "releaseTest",
+		"hypper.cattle.io/namespace": "namespaceTest",
+		"hypper.cattle.io/shared-dependencies": "  - name: foo" + "\n" +
+			"    version: \"0.1.0\"" + "\n" +
+			"    repository: \"\"" + "\n",
+	}
+	chartMetadataGood := &chart.Metadata{Annotations: annotations}
+
+	err := validateChartHypperSharedDepsCorrect(chartMetadataGood)
+	if err != nil {
+		t.Errorf("validateChartHypperRelease to not return a linter error, got %v", err)
+	}
+
+	annotationsBad := map[string]string{
+		"hypper.cattle.io/release-name": "releaseTest",
+		"hypper.cattle.io/namespace": "namespaceTest",
+		"hypper.cattle.io/shared-dependencies": "  - name: foo" + "\n" +
+			"    version: \"foo0.1.0\"" + "\n",
+	}
+	chartMetadataBad := &chart.Metadata{Annotations: annotationsBad}
+
+	err = validateChartHypperSharedDepsCorrect(chartMetadataBad)
+	if err == nil {
+		t.Errorf("validateChartHypperSharedDepsCorrect to return a linter error, got no error")
+	}
+
+}

--- a/pkg/lint/rules/annotations_test.go
+++ b/pkg/lint/rules/annotations_test.go
@@ -69,7 +69,7 @@ func TestValidateChartHypperRelease(t *testing.T) {
 func TestValidateChartHypperSharedDepsCorrect(t *testing.T) {
 	annotations := map[string]string{
 		"hypper.cattle.io/release-name": "releaseTest",
-		"hypper.cattle.io/namespace": "namespaceTest",
+		"hypper.cattle.io/namespace":    "namespaceTest",
 		"hypper.cattle.io/shared-dependencies": "  - name: foo" + "\n" +
 			"    version: \"0.1.0\"" + "\n" +
 			"    repository: \"\"" + "\n",
@@ -83,7 +83,7 @@ func TestValidateChartHypperSharedDepsCorrect(t *testing.T) {
 
 	annotationsBad := map[string]string{
 		"hypper.cattle.io/release-name": "releaseTest",
-		"hypper.cattle.io/namespace": "namespaceTest",
+		"hypper.cattle.io/namespace":    "namespaceTest",
 		"hypper.cattle.io/shared-dependencies": "  - name: foo" + "\n" +
 			"    version: \"foo0.1.0\"" + "\n",
 	}

--- a/pkg/lint/rules/testdata/goodchart/Chart.yaml
+++ b/pkg/lint/rules/testdata/goodchart/Chart.yaml
@@ -10,3 +10,4 @@ annotations:
   "hypper.cattle.io/namespace": "namespace"
   "hypper.cattle.io/shared-dependencies": |
     - name: shareddep
+      version: "~0.1.0"


### PR DESCRIPTION
Use `"github.com/Masterminds/semver/v3"` to validate, honor, and use the semver constraints listed in shared deps everywhere.
Which right now means:
- `hypper lint CHART`: semver constraint is now a must (we will ERROR if not present).
- `hyper shared-dep list CHART`:  filter against the constraint correctly, now outputting `status: out-of-range` if the installed dep doesn't satisfy what is needed.
- `hypper install CHART`: pull correct chart that satisfies the needed semver constraint. Error if the repository/cache doesn't contain a version that can satisfy it.

In addition, 
- Add related tests. For that, add new `pkg/chart/{Mock(),MockChartOptions()}` functions, since tests for dependencies need releases with charts that contain specific `Chart.Metadata.Version`. I suppose these functions will grow in the future, and we should think about upstreaming them.
- Fix a bug with ns when `hypper shared-dep list -n foo`.

Closes: https://github.com/rancher-sandbox/hypper/issues/90