### PR TITLE
docs: Update cli output and add optional-dep examples

### DIFF
--- a/docs/user/howto/expandcharthypper.md
+++ b/docs/user/howto/expandcharthypper.md
@@ -39,7 +39,7 @@ sources:
 version: 8.5.1
 ```
 
-But we want to install it always on the same namespace called `databases`
+But we want to install it always on the same namespace called `databases`.
 
 So we will expand the `Chart.yaml` to look like this:
 
@@ -78,9 +78,8 @@ We added the `hypper.cattle.io/namespace: databases` to the annotation, so now w
 
 ```console
 $ hypper install mysql/                 
-Installing chart "mysql" as "mysql" in namespace "databases"…
-Done! 👏 
-
+🛳  Installing chart "mysql" as "mysql" in namespace "databases"…
+👏 Done!
 ```
 
 See also how we didn't to specify any name for the release? Hypper is smart enough to try to obtain the name from the annotations (like the namespace!) and if it doesn't find it, it uses the name value on the `Chart.yaml`

--- a/docs/user/howto/lintchart.md
+++ b/docs/user/howto/lintchart.md
@@ -7,55 +7,119 @@ It's very simple, just run `hypper lint` against your chart, and it will verify 
 
 `hypper lint` runs both Helm checks and Hypper checks against the chart.
 
-If the linter encounters things that will cause the chart to fail installation, it will emit `[ERROR]` messages. If it encounters issues that break with convention or recommendation, it will emit `[WARNING]` messages.
+If the linter encounters things that will cause the chart to fail installation,
+it will emit `[ERROR]` messages. If it encounters issues that break with
+convention or recommendation, it will emit `[WARNING]` messages. For optional
+features, it will emit `[INFO]` messages.
 
-
-For example, running it against one of our test charts with Hypper annotations should produce a warning due to a missing icon:
+First, lets add the hypper-charts repo, to obtain some chart examples:
 
 ```console
-$ hypper lint cmd/hypper/testdata/testcharts/hypper-annot
-==> Linting cmd/hypper/testdata/testcharts/hypper-annot
+$ hypper repo add hypper-charts 'https://rancher-sandbox.github.io/hypper-charts/repo'
+"hypper-charts" has been added to your repositories
+$ hypper repo update
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "hypper-charts" chart repository
+🛳  Update Complete.
+$ hypper pull hypper-charts/our-app --untar
+
+```
+
+Now, let's lint. For example, linting against one of our test charts with
+Hypper annotations should produce a warning due to a missing icon:
+
+```console
+$ hypper lint ./our-app
+==> Linting our-app/
 [INFO] Chart.yaml: icon is recommended
 
 1 chart(s) linted, 0 chart(s) failed
 ```
 
 
-While running it against a vanilla Helm chart with no extra Hypper annotations will emit several `[WARNING]`, recommending to set certain values that Hypper supports:
+While running it against a vanilla Helm chart with no extra Hypper annotations
+will emit several `[INFO]`, recommending to set certain values that Hypper
+supports:
 
 
 ```console
-$ hypper lint cmd/hypper/testdata/testcharts/vanilla-helm 
-==> Linting cmd/hypper/testdata/testcharts/vanilla-helm
-[INFO] Chart.yaml: icon is recommended
+$ hypper repo add bitnami https://charts.bitnami.com/bitnami
+"bitnami" has been added to your repositories
+
+$ hypper repo update
+Hang tight while we grab the latest from your chart repositories...
+...Successfully got an update from the "hypper-charts" chart repository
+...Successfully got an update from the "bitnami" chart repository
+🛳  Update Complete.
+
+$ hypper pull bitnami/mariadb --untar
+
+$ hypper lint ./mariadb
+==> Linting ./mariadb
 [INFO] Chart.yaml: Setting hypper.cattle.io/release-name in annotations is recommended
 [INFO] Chart.yaml: Setting hypper.cattle.io/namespace in annotations is recommended
-[INFO] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is recommended
+[INFO] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is optional
+[INFO] Chart.yaml: Setting hypper.cattle.io/optional-dependencies in annotations is optional
 
 1 chart(s) linted, 0 chart(s) failed
 ```
 
-Running against a shared-dependencies annotation that is malformed will emit an `[ERROR]`:
+Running against a shared-dependencies annotation that is malformed will emit an `[ERROR]`. Let's edit the MariaDB chart, so it has a wrong `shared-dependencies` stanza, for example. Make the ./mariadb/Chart.yaml look like this:
+
+```diff
+# this is a diff of ./mariadb/Cahrt.yaml
+
+annotations:
+  category: Database
++  hypper.cattle.io/shared-dependencies: |
++    - name: fleet
++      version: "this-is-incorrect-0.3.500"
++      repository: "https://rancher-sandbox.github.io/hypper-charts/repo"
+apiVersion: v2
+appVersion: 10.5.10
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  tags:
+  - bitnami-common
+  version: 1.x.x
+description: Fast, reliable, scalable, and easy to use open-source relational database
+  system. MariaDB Server is intended for mission-critical, heavy-load production systems
+  as well as for embedding into mass-deployed software. Highly available MariaDB cluster.
+home: https://github.com/bitnami/charts/tree/master/bitnami/mariadb
+icon: https://bitnami.com/assets/stacks/mariadb/img/mariadb-stack-220x234.png
+keywords:
+- mariadb
+- mysql
+- database
+- sql
+- prometheus
+maintainers:
+- email: containers@bitnami.com
+  name: Bitnami
+name: mariadb
+sources:
+- https://github.com/bitnami/bitnami-docker-mariadb
+- https://github.com/prometheus/mysqld_exporter
+- https://mariadb.org
+version: 9.3.11
+
+```
+
 
 ```console
-$ hypper lint cmd/hypper/testdata/testcharts/hypper-annot
-==> Linting cmd/hypper/testdata/testcharts/hypper-annot
-[INFO] Chart.yaml: icon is recommended
-[ERROR] Chart.yaml: Shared dependencies list is broken, please check the correct format
+$ hypper lint ./mariadb
+==> Linting ./mariadb
+[INFO] Chart.yaml: Setting hypper.cattle.io/release-name in annotations is recommended
+[INFO] Chart.yaml: Setting hypper.cattle.io/namespace in annotations is recommended
+[INFO] Chart.yaml: Setting hypper.cattle.io/optional-dependencies in annotations is optional
+[ERROR] Chart.yaml: Shared dependency version is broken: improper constraint: this-is-incorrect-0.3.500
 
 Error: 1 chart(s) linted, 1 chart(s) failed
 ```
 
 
-Now if you were to set some kind of automated CI in place to check for linting and are required to have Hypper annotations as mandatory, you can run `hypper lint` with the `--strict` flag so all warnings are marked as errors.
-
-```console
-$ hypper lint cmd/hypper/testdata/testcharts/fallback-annot --strict
-==> Linting cmd/hypper/testdata/testcharts/fallback-annot
-[INFO] Chart.yaml: icon is recommended
-[WARNING] Chart.yaml: Setting hypper.cattle.io/release-name in annotations is recommended
-[WARNING] Chart.yaml: Setting hypper.cattle.io/namespace in annotations is recommended
-[WARNING] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is recommended
-
-Error: 1 chart(s) linted, 1 chart(s) failed
-```
+Now if you were to set some kind of automated CI in place to check for linting
+and are required to have Hypper annotations as mandatory, you can run `hypper
+lint` with the `--strict` flag so all warnings are marked as errors. For now, we
+don't have warning-level messages.

--- a/docs/user/tutorials/quickstart.md
+++ b/docs/user/tutorials/quickstart.md
@@ -70,14 +70,20 @@ all users of the cluster. Think of them as typical system OS libraries/services.
 The commands are the same as you have already used:
 
 ```console
-$ hypper install hypper-charts/fleet --create-namespace
-🛳  Installing chart "fleet" as "fleet" in namespace "fleet-system"…
+$ hypper install hypper-charts/our-app --create-namespace
+🛳  Installing shared dependencies for chart "our-app":
+🛳  - Installing chart "fleet" as "fleet" in namespace "fleet-system"…
+❓ Install optional shared dependency "rancher-tracing" ? [Y/n]:
+y
+🛳  - Installing chart "rancher-tracing" as "rancher-tracing" in namespace "istio-system"…
+🛳  Installing chart "our-app" as "our-app-name" in namespace "hypper"…
 👏 Done!
 ```
 
-This time, the chart got installed with a default name `fleet`, and into a
-default namespace  `fleet-system`. We passed the flag `--create-namespace` to
-tell Hypper to create the namespace if it doesn't exist.
+This time, the chart got installed with a default name `our-app-name`, and into
+a default namespace  `hypper`. We passed the flag `--create-namespace` to tell
+Hypper to create the namespace if it doesn't exist. It also installed its
+defined shared and optional shared dependencies.
 
 ## Learn about releases
 
@@ -85,9 +91,11 @@ It's easy to see what has been released with hypper:
 
 ```console
 $ hypper ls --all-namespaces
-NAME       NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                 APP VERSION
-fleet      fleet-system    1               2021-03-12 12:06:35.951012048 +0100 CET deployed        fleet-0.3.400         0.3.4
-mariadb    default         1               2021-03-12 12:09:46.670491535 +0100 CET deployed        mariadb-9.3.5         10.5.9
+NAME            NAMESPACE       REVISION        UPDATED                                         STATUS          CHART                           APP VERSION
+fleet           fleet-system    1               2021-05-18 15:44:16.11805509 +0200 CEST         deployed        fleet-0.3.500                   0.3.5
+mariadb         default         1               2021-05-18 15:44:43.106328879 +0200 CEST        deployed        mariadb-9.3.11                  10.5.10
+our-app-name    hypper          1               2021-05-18 15:44:18.687033582 +0200 CEST        deployed        our-app-0.0.2                   0.0.1
+rancher-tracing istio-system    1               2021-05-18 15:44:18.592656807 +0200 CEST        deployed        rancher-tracing-1.20.002        1.20.0
 ```
 
 ## Uninstall a release

--- a/docs/user/tutorials/quickstart.md
+++ b/docs/user/tutorials/quickstart.md
@@ -51,8 +51,8 @@ this case the Bitnami chart repository.
 
 ```console
 $ hypper install mariadb bitnami/mariadb
-Installing chart "mariadb" in namespace "default"…
-Done! 👏
+🛳  Installing chart "mariadb" as "mariadb" in namespace "default"…
+👏 Done!
 ```
 
 Whenever you install a chart, a new release is created. So one Helm chart can be
@@ -71,8 +71,8 @@ The commands are the same as you have already used:
 
 ```console
 $ hypper install hypper-charts/fleet --create-namespace
-Installing chart "fleet" as "fleet" in namespace "fleet-system"…
-Done! 👏
+🛳  Installing chart "fleet" as "fleet" in namespace "fleet-system"…
+👏 Done!
 ```
 
 This time, the chart got installed with a default name `fleet`, and into a
@@ -97,7 +97,7 @@ To uninstall a release, use the hypper uninstall command:
 ```console
 $ hypper uninstall fleet -n fleet-system
 🔥  uninstalling fleet
-🔥  release "fleet" uninstalled
+✅  release "fleet" uninstalled
 ```
 
 This will uninstall fleet from Kubernetes, which will remove all resources


### PR DESCRIPTION
Update docs with current CLI output and optional-deps examples for
`hypper install`, `hypper lint`, and `hypper shared-deps list`.

Comes together with https://github.com/rancher-sandbox/hypper-charts/pull/5. 


Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>