### PR TITLE
Configure CLI to print errors using log-go

### DIFF
--- a/cmd/hypper/hypper.go
+++ b/cmd/hypper/hypper.go
@@ -25,7 +25,6 @@ import (
 	logcli "github.com/Masterminds/log-go/impl/cli"
 	"github.com/rancher-sandbox/hypper/pkg/action"
 	"github.com/rancher-sandbox/hypper/pkg/cli"
-	"github.com/rancher-sandbox/hypper/pkg/eyecandy"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 	helmAction "helm.sh/helm/v3/pkg/action"
@@ -57,7 +56,7 @@ func main() {
 	}
 
 	if err != nil {
-		logger.Debug(eyecandy.Magenta("%v"), err)
+		logger.Error(err)
 		os.Exit(1)
 	}
 
@@ -72,7 +71,7 @@ func main() {
 	})
 
 	if err := cmd.Execute(); err != nil {
-		logger.Debug(eyecandy.Magenta("%v"), err)
+		logger.Error(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -150,6 +150,10 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 		mem.SetNamespace(settings.Namespace())
 	}
 	c, err := root.ExecuteC()
+	if err != nil {
+		logger.Error(err)
+	}
+
 	result := buf.String()
 	os.Stdin = oldStdin
 
@@ -214,6 +218,10 @@ func executeCommandStdinC(cmd string) (*cobra.Command, string, error) {
 	oldStdin := os.Stdin
 
 	c, err := root.ExecuteC()
+	if err != nil {
+		logger.Error(err)
+	}
+
 	result := buf.String()
 	os.Stdin = oldStdin
 

--- a/cmd/hypper/hypper_test.go
+++ b/cmd/hypper/hypper_test.go
@@ -122,9 +122,13 @@ func executeActionCommandStdinC(store *storage.Storage, in *os.File, cmd string)
 	// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
 	buf := new(bytes.Buffer)
 	logger := logcli.NewStandard()
+	logger.TraceOut = buf
+	logger.DebugOut = buf
 	logger.InfoOut = buf
 	logger.WarnOut = buf
 	logger.ErrorOut = buf
+	logger.FatalOut = buf
+	logger.PanicOut = buf
 	log.Current = logger
 
 	root, err := newRootCmd(actionConfig, log.Current, args)
@@ -189,8 +193,13 @@ func executeCommandStdinC(cmd string) (*cobra.Command, string, error) {
 	// create our own Logger that satisfies impl/cli.Logger, but with a buffer for tests
 	buf := new(bytes.Buffer)
 	logger := logcli.NewStandard()
+	logger.TraceOut = buf
+	logger.DebugOut = buf
 	logger.InfoOut = buf
+	logger.WarnOut = buf
 	logger.ErrorOut = buf
+	logger.FatalOut = buf
+	logger.PanicOut = buf
 	log.Current = logger
 
 	root, err := newRootCmd(actionConfig, log.Current, args)

--- a/cmd/hypper/root.go
+++ b/cmd/hypper/root.go
@@ -34,10 +34,11 @@ A package manager built on Helm charts and Helm itself.
 
 func newRootCmd(actionConfig *action.Configuration, logger log.Logger, args []string) (*cobra.Command, error) {
 	cmd := &cobra.Command{
-		Use:          "hypper",
-		Short:        "A package manager built on Helm charts and Helm itself",
-		Long:         globalUsage,
-		SilenceUsage: true,
+		Use:           "hypper",
+		Short:         "A package manager built on Helm charts and Helm itself",
+		Long:          globalUsage,
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	flags := cmd.PersistentFlags()

--- a/cmd/hypper/testdata/output/install-incorrect-flag-optional-deps.txt
+++ b/cmd/hypper/testdata/output/install-incorrect-flag-optional-deps.txt
@@ -1,1 +1,1 @@
-Error: invalid argument "foo" for "--optional-deps" flag: must be 'all', 'ask', 'none'
+ERROR: invalid argument "foo" for "--optional-deps" flag: must be 'all', 'ask', 'none'

--- a/cmd/hypper/testdata/output/install-no-chart.txt
+++ b/cmd/hypper/testdata/output/install-no-chart.txt
@@ -1,3 +1,3 @@
-Error: "hypper install" requires at least 1 argument
+ERROR: "hypper install" requires at least 1 argument
 
 Usage:  hypper install [NAME] [CHART] [flags]

--- a/cmd/hypper/testdata/output/install-with-shared-deps-out-of-range.txt
+++ b/cmd/hypper/testdata/output/install-with-shared-deps-out-of-range.txt
@@ -1,3 +1,3 @@
 🛳  Installing shared dependencies for chart "empty":
 ERROR: ❌  Satisfiable version for chart "testdata/testcharts/shared-dep" not found, aborting
-Error: Satisfiable chart version not found; 0.1.0 is less than 0.3.0
+ERROR: Satisfiable chart version not found; 0.1.0 is less than 0.3.0

--- a/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts-with-subcharts-windows.txt
+++ b/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts-with-subcharts-windows.txt
@@ -29,4 +29,4 @@
 [INFO] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is optional
 [INFO] Chart.yaml: Setting hypper.cattle.io/optional-dependencies in annotations is optional
 
-Error: 3 chart(s) linted, 2 chart(s) failed
+ERROR: 3 chart(s) linted, 2 chart(s) failed

--- a/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
+++ b/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts-with-subcharts.txt
@@ -29,4 +29,4 @@
 [INFO] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is optional
 [INFO] Chart.yaml: Setting hypper.cattle.io/optional-dependencies in annotations is optional
 
-Error: 3 chart(s) linted, 2 chart(s) failed
+ERROR: 3 chart(s) linted, 2 chart(s) failed

--- a/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts.txt
+++ b/cmd/hypper/testdata/output/lint-chart-with-bad-subcharts.txt
@@ -8,4 +8,4 @@
 [INFO] Chart.yaml: Setting hypper.cattle.io/shared-dependencies in annotations is optional
 [INFO] Chart.yaml: Setting hypper.cattle.io/optional-dependencies in annotations is optional
 
-Error: 1 chart(s) linted, 1 chart(s) failed
+ERROR: 1 chart(s) linted, 1 chart(s) failed

--- a/cmd/hypper/testdata/output/shared-deps-list-no-chart-linux.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-chart-linux.txt
@@ -1,1 +1,1 @@
-Error: stat /no/such/chart: no such file or directory
+ERROR: stat /no/such/chart: no such file or directory

--- a/cmd/hypper/testdata/output/shared-deps-list-no-chart-windows.txt
+++ b/cmd/hypper/testdata/output/shared-deps-list-no-chart-windows.txt
@@ -1,1 +1,1 @@
-Error: CreateFile \no\such\chart: The system cannot find the path specified.
+ERROR: CreateFile \no\such\chart: The system cannot find the path specified.

--- a/cmd/hypper/testdata/output/uninstall-no-args.txt
+++ b/cmd/hypper/testdata/output/uninstall-no-args.txt
@@ -1,3 +1,3 @@
-Error: "hypper uninstall" requires at least 1 argument
+ERROR: "hypper uninstall" requires at least 1 argument
 
 Usage:  hypper uninstall [NAME] [flags]

--- a/cmd/hypper/testdata/output/upgrade-with-bad-dependencies.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-bad-dependencies.txt
@@ -1,1 +1,1 @@
-Error: cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator
+ERROR: cannot load Chart.yaml: error converting YAML to JSON: yaml: line 6: did not find expected '-' indicator

--- a/cmd/hypper/testdata/output/upgrade-with-bad-or-missing-existing-release.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-bad-or-missing-existing-release.txt
@@ -1,1 +1,1 @@
-Error: UPGRADE FAILED: "funny-bunny" has no deployed releases
+ERROR: UPGRADE FAILED: "funny-bunny" has no deployed releases

--- a/cmd/hypper/testdata/output/upgrade-with-missing-dependencies.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-missing-dependencies.txt
@@ -1,1 +1,1 @@
-Error: found in Chart.yaml, but missing in charts/ directory: reqsubchart2
+ERROR: found in Chart.yaml, but missing in charts/ directory: reqsubchart2

--- a/cmd/hypper/testdata/output/upgrade-with-pending-install.txt
+++ b/cmd/hypper/testdata/output/upgrade-with-pending-install.txt
@@ -1,1 +1,1 @@
-Error: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress
+ERROR: UPGRADE FAILED: another operation (install/upgrade/rollback) is in progress

--- a/pkg/action/lint.go
+++ b/pkg/action/lint.go
@@ -104,7 +104,7 @@ func lintChart(path string, vals map[string]interface{}, namespace string, stric
 
 	// Guard: Error out if this is not a chart.
 	if _, err := os.Stat(filepath.Join(chartPath, "Chart.yaml")); err != nil {
-		return linter, nil
+		return linter, errors.Wrap(err, "unable to check Chart.yaml file in chart")
 	}
 
 	return lint.All(chartPath, vals, namespace, strict), nil


### PR DESCRIPTION
Configure cobra to not print errors, we will print the floated errors ourselves.
Fix test setup to funnel all errors to the same buffer, and print them to goldenfiles.
E.g: See that all printed errors now start with `ERROR:` (log-go, with colors, etc) and not `Error: ` (cobra).

Also, print error in pkg/ when one cannot open `Chart.yaml` in `hypper lint`.

Closes: https://github.com/rancher-sandbox/hypper/issues/155