### PR TITLE
feat: Default to creating namespaces

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -97,7 +97,7 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 }
 
 func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Install, valueOpts *values.Options) {
-	f.BoolVar(&client.CreateNamespace, "create-namespace", false, "create the release namespace if not present")
+	f.BoolVar(&client.NoCreateNamespace, "no-create-namespace", false, "don't create the release namespace if not present")
 	f.BoolVar(&client.NoSharedDeps, "no-shared-deps", false, "skip installation of shared dependencies")
 	f.Var(enumflag.New(&optionaldepsmode, "option", OptionalDepsModeIds, enumflag.EnumCaseInsensitive),
 		"optional-deps", "install optional shared dependencies [ask|all|none]")
@@ -123,6 +123,9 @@ func runInstall(args []string, client *action.Install, valueOpts *values.Options
 	case OptionalDepsNone:
 		client.OptionalDeps = action.OptionalDepsNone
 	}
+
+	// map hypper's NoCreateNamespace to Helm's CreateNamespace
+	client.CreateNamespace = !client.NoCreateNamespace
 
 	chart, err := client.Chart(args)
 	if err != nil {

--- a/cmd/hypper/install_test.go
+++ b/cmd/hypper/install_test.go
@@ -35,11 +35,12 @@ func TestInstallCmd(t *testing.T) {
 			cmd:    "install zeppelin testdata/testcharts/hypper-annot -n led --no-shared-deps",
 			golden: "output/install-name-ns-args.txt",
 		},
-		// Install, name and namespace as args, create ns
+		// Install, name and namespace as args, no create ns
 		{
-			name:   "install, name and ns as args",
-			cmd:    "install purple testdata/testcharts/hypper-annot --namespace deep --create-namespace --no-shared-deps",
-			golden: "output/install-create-namespace.txt",
+			name:   "install, name and ns as args, don't create ns",
+			cmd:    "install purple testdata/testcharts/hypper-annot --namespace deep --no-create-namespace --no-shared-deps",
+			golden: "output/install-no-create-namespace.txt",
+			// wantError: true, there's no error, the client allows targetting any ns
 		},
 		// Install, hypper annot have priority over fallback annot
 		{

--- a/cmd/hypper/testdata/output/install-no-create-namespace.txt
+++ b/cmd/hypper/testdata/output/install-no-create-namespace.txt
@@ -1,0 +1,2 @@
+🛳  Installing chart "empty" as "purple" in namespace "deep"…
+👏 Done!

--- a/cmd/hypper/upgrade.go
+++ b/cmd/hypper/upgrade.go
@@ -74,7 +74,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 	client := action.NewUpgrade(cfg)
 	valueOpts := &values.Options{}
 	var outfmt output.Format
-	var createNamespace bool
+	var noCreateNamespace bool
 
 	cmd := &cobra.Command{
 		Use:   "upgrade [CHART]",
@@ -129,7 +129,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 					// Set namespace for the install client
 					action.SetNamespace(client, ch, settings.Namespace(), settings.NamespaceFromFlag)
 
-					instClient.CreateNamespace = createNamespace
+					instClient.CreateNamespace = !noCreateNamespace
 					instClient.ChartPathOptions = client.ChartPathOptions
 					instClient.DryRun = client.DryRun
 					instClient.DisableHooks = client.DisableHooks
@@ -183,7 +183,7 @@ func newUpgradeCmd(cfg *action.Configuration, logger log.Logger) *cobra.Command 
 	}
 
 	f := cmd.Flags()
-	f.BoolVar(&createNamespace, "create-namespace", false, "if --install is set, create the release namespace if not present")
+	f.BoolVar(&noCreateNamespace, "no-create-namespace", false, "if --install is set, don't create the release namespace if not present")
 	f.BoolVarP(&client.Install, "install", "i", false, "if a release by this name doesn't already exist, run an install")
 	f.BoolVar(&client.Devel, "devel", false, "use development versions, too. Equivalent to version '>0.0.0-0'. If --version is set, this is ignored")
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an upgrade")

--- a/docs/user/howto/shared-deps.md
+++ b/docs/user/howto/shared-deps.md
@@ -115,7 +115,7 @@ Hang tight while we grab the latest from your chart repositories...
 Now we install `fleet`:
 
 ```console
-$ hypper install hypper-charts/fleet -n fleet-system --create-namespace
+$ hypper install hypper-charts/fleet -n fleet-system
 Installing chart "fleet" as "fleet" in namespace "fleet-system"…
 Done! 👏
 ```
@@ -134,7 +134,7 @@ By default, Hypper asks for each optional shared dependency if we want to
 install it or not:
 
 ```console
-$ hypper install ./our-app --create-namespace
+$ hypper install ./our-app
 🛳  Installing shared dependencies for chart "our-app":
 ℹ️  - Shared dependency chart "fleet" already installed, skipping
 ❓ Install optional shared dependency "rancher-tracing" ? [Y/n]:

--- a/docs/user/tutorials/quickstart.md
+++ b/docs/user/tutorials/quickstart.md
@@ -70,7 +70,7 @@ all users of the cluster. Think of them as typical system OS libraries/services.
 The commands are the same as you have already used:
 
 ```console
-$ hypper install hypper-charts/our-app --create-namespace
+$ hypper install hypper-charts/our-app
 🛳  Installing shared dependencies for chart "our-app":
 🛳  - Installing chart "fleet" as "fleet" in namespace "fleet-system"…
 ❓ Install optional shared dependency "rancher-tracing" ? [Y/n]:
@@ -81,9 +81,9 @@ y
 ```
 
 This time, the chart got installed with a default name `our-app-name`, and into
-a default namespace  `hypper`. We passed the flag `--create-namespace` to tell
-Hypper to create the namespace if it doesn't exist. It also installed its
-defined shared and optional shared dependencies.
+a default namespace  `hypper`. Hypper to creates the namespace if it doesn't
+exist (you can pass `--no-create-namespace` if you don't want that). It also
+installed its defined shared and optional shared dependencies.
 
 ## Learn about releases
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -58,8 +58,9 @@ type Install struct {
 	*action.Install
 
 	// hypper specific
-	NoSharedDeps bool
-	OptionalDeps optionalDepsStrategy
+	NoSharedDeps      bool
+	OptionalDeps      optionalDepsStrategy
+	NoCreateNamespace bool
 
 	// Config stores the actionconfig so it can be retrieved and used again
 	Config *Configuration


### PR DESCRIPTION
Default to creating ns in `hypper install` and `hypper upgrade`.

Add new flag `--no-create-namespace`, defaults to false, so namespaces are created by default.
Drop old flag `--create-namespace`.

Update present tests and docs.

Closes: https://github.com/rancher-sandbox/hypper/issues/162