### PR TITLE
Print ASCII tree on `hypper install`

### DIFF
--- a/cmd/hypper/testdata/output/install-dry-run-with-all-optional-deps.txt
+++ b/cmd/hypper/testdata/output/install-dry-run-with-all-optional-deps.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+empty v0.1.0
+ ├─ testdata/testcharts/shared-dep v0.1.0
+ └─ testdata/testcharts/vanilla-helm v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "empty" as "empty" in namespace "default"…
 🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…

--- a/cmd/hypper/testdata/output/install-hypper-annot.txt
+++ b/cmd/hypper/testdata/output/install-hypper-annot.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+empty v0.1.0
+ ├─ testdata/testcharts/shared-dep v0.1.0
+ └─ testdata/testcharts/vanilla-helm v0.1.0
+
 ⏭  Skipping dependency "testdata/testcharts/shared-dep", flag `no-shared-deps` has been set
 ⏭  Skipping dependency "testdata/testcharts/vanilla-helm", flag `no-shared-deps` has been set
 🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…

--- a/cmd/hypper/testdata/output/install-name-ns-args.txt
+++ b/cmd/hypper/testdata/output/install-name-ns-args.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+empty v0.1.0
+ ├─ testdata/testcharts/shared-dep v0.1.0
+ └─ testdata/testcharts/vanilla-helm v0.1.0
+
 ⏭  Skipping dependency "testdata/testcharts/shared-dep", flag `no-shared-deps` has been set
 ⏭  Skipping dependency "testdata/testcharts/vanilla-helm", flag `no-shared-deps` has been set
 🛳  Installing chart "empty" as "zeppelin" in namespace "led"…

--- a/cmd/hypper/testdata/output/install-no-create-namespace.txt
+++ b/cmd/hypper/testdata/output/install-no-create-namespace.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+empty v0.1.0
+ ├─ testdata/testcharts/shared-dep v0.1.0
+ └─ testdata/testcharts/vanilla-helm v0.1.0
+
 ⏭  Skipping dependency "testdata/testcharts/shared-dep", flag `no-shared-deps` has been set
 ⏭  Skipping dependency "testdata/testcharts/vanilla-helm", flag `no-shared-deps` has been set
 🛳  Installing chart "empty" as "purple" in namespace "deep"…

--- a/cmd/hypper/testdata/output/install-skip-all-optional-deps.txt
+++ b/cmd/hypper/testdata/output/install-skip-all-optional-deps.txt
@@ -1,3 +1,7 @@
+The following charts are going to be installed:
+empty v0.1.0
+ └─ testdata/testcharts/shared-dep v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
 👏 Done!

--- a/cmd/hypper/testdata/output/install-with-all-optional-deps.txt
+++ b/cmd/hypper/testdata/output/install-with-all-optional-deps.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+empty v0.1.0
+ ├─ testdata/testcharts/shared-dep v0.1.0
+ └─ testdata/testcharts/vanilla-helm v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "empty" as "empty" in namespace "default"…
 🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…

--- a/cmd/hypper/testdata/output/install-with-shared-deps.txt
+++ b/cmd/hypper/testdata/output/install-with-shared-deps.txt
@@ -1,3 +1,7 @@
+The following charts are going to be installed:
+empty v0.1.0
+ └─ testdata/testcharts/shared-dep v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "empty" as "my-hypper-name" in namespace "hypper"…
 👏 Done!

--- a/internal/solver/testdata/output/format-sat-install1-table.txt
+++ b/internal/solver/testdata/output/format-sat-install1-table.txt
@@ -1,6 +1,6 @@
 Status: SAT
 Packages to be installed:
-bar  1.0.0
+bar v1.0.0
 
 Packages to be removed:
 

--- a/internal/solver/testdata/output/format-sat-upgrade-table.txt
+++ b/internal/solver/testdata/output/format-sat-upgrade-table.txt
@@ -1,6 +1,6 @@
 Status: SAT
 Packages to be installed:
-bar  1.0.0
+bar v1.0.0
 
 Packages to be removed:
 

--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -188,6 +188,10 @@ func (i *Install) Run(strategy solver.SolverStrategy,
 	s.Solve(wantedPkgInDB)
 
 	if s.IsSAT() {
+		if len(s.PkgResultSet.ToInstall.Relations) != 0 {
+			logger.Info("The following charts are going to be installed:")
+			logger.Infof("%s\n", solver.PrintPkgTree(s.PkgResultSet.ToInstall))
+		}
 		installedRels, err := i.postOrderInstall(s.PkgResultSet.ToInstall, wantedPkgInDB, wantedChrt, vals, settings, logger)
 		if err != nil {
 			return installedRels, err

--- a/pkg/action/testdata/output/install-correctly-optional-shared-deps.txt
+++ b/pkg/action/testdata/output/install-correctly-optional-shared-deps.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ testdata/charts/vanilla-helm v0.1.0
+
 🛳  Installing chart "empty" as "empty" in namespace "default"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "luke-skywalker"…

--- a/pkg/action/testdata/output/install-correctly-shared-deps-looped-repo-file.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps-looped-repo-file.txt
@@ -1,3 +1,8 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ local-dep-empty v0.1.0
+    └─ local-dep2-empty v0.1.0
+
 🛳  Installing chart "local-dep2-empty" as "my-hypper-name2" in namespace "hypper"…
 🛳  Installing chart "local-dep-empty" as "my-hypper-name" in namespace "hypper"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "hypper"…

--- a/pkg/action/testdata/output/install-correctly-shared-deps-repo-file.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps-repo-file.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ shared-dep-empty v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "hypper"…

--- a/pkg/action/testdata/output/install-correctly-shared-deps.txt
+++ b/pkg/action/testdata/output/install-correctly-shared-deps.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ testdata/charts/shared-dep v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "hypper"…

--- a/pkg/action/testdata/output/install-shared-deps-dry-run.txt
+++ b/pkg/action/testdata/output/install-shared-deps-dry-run.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ testdata/charts/shared-dep v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "hypper"…

--- a/pkg/action/testdata/output/install-shared-deps-with-ns-from-flag.txt
+++ b/pkg/action/testdata/output/install-shared-deps-with-ns-from-flag.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ testdata/charts/shared-dep v0.1.0
+
 🛳  Installing chart "shared-dep-empty" as "my-shared-dep" in namespace "my-shared-dep-ns"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "ns-from-flag"…

--- a/pkg/action/testdata/output/install-shared-deps-without-annotations.txt
+++ b/pkg/action/testdata/output/install-shared-deps-without-annotations.txt
@@ -1,2 +1,6 @@
+The following charts are going to be installed:
+hello v0.1.0
+ └─ testdata/charts/vanilla-helm v0.1.0
+
 🛳  Installing chart "empty" as "empty" in namespace "default"…
 🛳  Installing chart "hello" as "test-install-release" in namespace "hypper"…


### PR DESCRIPTION
This PR adds an ASCII tree of charts to be installed, when doing `hypper install`. Example:
```console
$ hypper install ./local-hypper-charts/charts/demo --dry-run        
The following charts are going to be installed:
demo v0.2.0
 ├─ demo-a v0.1.0
 ├─ demo-b v0.2.0
 │  └─ demo-c v0.1.0
 └─ demo-d v0.2.0

🛳  Installing chart "demo-a" as "demo-a" in namespace "demo-a"…
🛳  Installing chart "demo-c" as "demo-c" in namespace "demo-c"…
🛳  Installing chart "demo-b" as "demo-b" in namespace "demo-b"…
🛳  Installing chart "demo-d" as "demo-d" in namespace "demo-d"…
🛳  Installing chart "demo" as "demoit" in namespace "demo"…
👏 Done!
```
(in console the ASCII pipes are continuous, GH markdown makes a mess).

Closes https://github.com/rancher-sandbox/hypper/issues/178. 