### PR TITLE
Fixing db not looking at repos

### DIFF
--- a/pkg/action/install.go
+++ b/pkg/action/install.go
@@ -141,7 +141,8 @@ func (i *Install) Run(strategy solver.SolverStrategy,
 		pkg.Unknown, pkg.Present, pinnedVer, i.ChartPathOptions.RepoURL, wantedChrtAbsPath)
 
 	// get all repo entries, continue if there's none:
-	rf, err := repo.LoadFile(settings.EnvSettings.RegistryConfig)
+	rf, err := repo.LoadFile(settings.EnvSettings.RepositoryConfig)
+
 	if err != nil {
 		if !os.IsNotExist(errors.Cause(err)) {
 			return nil, err


### PR DESCRIPTION
When f19146a15ac4c750efc2e05ac988b7c04bc598d6 landed the repo
location was switched for the registry location. The registry is
used with OCI. This was likely an accidental autocomplete name
change. It caused the solver to be unaware of the repos and charts
within them. Changing to the right location fixes the issue.

Closes #181