### PR TITLE
Fixing issue where charts in repos not erroring on dep issues

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -83,6 +85,12 @@ func newInstallCmd(actionConfig *action.Configuration, logger log.Logger) *cobra
 			// TODO decide how to use returned rel:
 			_, err := runInstall(solver.InstallOne, args, client, valueOpts, logger)
 			if err != nil {
+				// Capturing a specific error message, when a chart in a repo
+				// was called for but the repo was never added. Adding more
+				// context for the user.
+				if strings.HasPrefix(err.Error(), "unable to load dependency") {
+					logger.Info("Please add any missing repositories, if necessary")
+				}
 				err = errors.New(eyecandy.ESPrintf(settings.NoEmojis, ":x: %s", err))
 				return err
 			}

--- a/pkg/action/world.go
+++ b/pkg/action/world.go
@@ -184,8 +184,8 @@ func (i *Install) CreateDepRelsFromAnnot(p *pkg.Pkg,
 					}
 				}
 				// Local charts (where there is no scheme) and those specified
-				// with the file scheme can be processed. They are local. Any
-				// chart that is in a repository should be from an added repo.
+				// with the file scheme can be processed. They are local. No
+				// dependencies will be pulled from repos not added to Hypper.
 				// Adding a repo enables a user to opt-in for security purposes.
 				// This is what linux system package managers do and it has been
 				// a recommendation from security reviews for Helm.


### PR DESCRIPTION
The situation is that you have A > B > C. The repo containing B and
C are missing. The code to load files was loading B but not C.
The solver would silently skip C and just install A and B.

For security reasons, we should not install charts from repos
when the repo has not been explicitly added. This is out other
system package managers work and is security guidance out of
reviews of Helm.

The solution here was to look for local files and then throw
an error if a depenency isn't a local file or in a repo.

Closes #182