### PR TITLE
feat: Add `hypper install --{timeout,wait,wait-for-jobs}`

### DIFF
--- a/cmd/hypper/install.go
+++ b/cmd/hypper/install.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -112,6 +113,9 @@ func addInstallFlags(cmd *cobra.Command, f *pflag.FlagSet, client *action.Instal
 	f.Var(enumflag.New(&optionaldepsmode, "option", OptionalDepsModeIds, enumflag.EnumCaseInsensitive),
 		"optional-deps", "install optional shared dependencies [ask|all|none]")
 	f.BoolVar(&client.DryRun, "dry-run", false, "simulate an install")
+	f.DurationVar(&client.Timeout, "timeout", 300*time.Second, "time to wait for any individual Kubernetes operation (like Jobs for hooks)")
+	f.BoolVar(&client.Wait, "wait", false, "if set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
+	f.BoolVar(&client.WaitForJobs, "wait-for-jobs", false, "if set and --wait enabled, will wait until all Jobs have been completed before marking the release as successful. It will wait for as long as --timeout")
 }
 
 func runInstall(strategy solver.SolverStrategy, args []string, client *action.Install, valueOpts *values.Options, logger log.Logger) ([]*release.Release, error) {


### PR DESCRIPTION
Analogous to the Helm install flags.
No need for tests; the codepath is tested by Helm SDK.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>